### PR TITLE
Upgrade to Flutter 3.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlin_version = '1.6.10'
-    ext.gradle_version = '7.0.4'
+    ext.gradle_version = '7.1.3'
     repositories {
         google()
         mavenCentral()

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,7 +105,7 @@ packages:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -434,14 +434,14 @@ packages:
       name: permission_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.2.0"
+    version: "10.0.0"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.0.2"
+    version: "10.0.0"
   permission_handler_apple:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -133,7 +133,7 @@ packages:
       name: file_picker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.5.0"
+    version: "4.6.1"
   file_testing:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.2"
   coverage:
     dependency: transitive
     description:
@@ -159,7 +159,7 @@ packages:
       name: flutter_blue_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   flutter_driver:
     dependency: "direct dev"
     description: flutter
@@ -497,7 +497,7 @@ packages:
       name: protobuf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   pub_semver:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -518,7 +518,7 @@ packages:
       name: sembast
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.0+1"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -378,7 +378,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.11"
   path_provider_android:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -329,14 +329,14 @@ packages:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.2"
   package_info_plus_linux:
     dependency: transitive
     description:
       name: package_info_plus_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.5"
   package_info_plus_macos:
     dependency: transitive
     description:
@@ -357,14 +357,14 @@ packages:
       name: package_info_plus_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   package_info_plus_windows:
     dependency: transitive
     description:
       name: package_info_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   path:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "30.0.0"
+    version: "41.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.7.0"
+    version: "4.2.0"
   app_settings:
     dependency: "direct main"
     description:
@@ -28,7 +28,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.6"
+    version: "3.1.11"
   args:
     dependency: transitive
     description:
@@ -64,13 +64,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
-  cli_util:
-    dependency: transitive
-    description:
-      name: cli_util
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.3.1"
   clock:
     dependency: transitive
     description:
@@ -84,7 +77,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
@@ -98,7 +91,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.2.0"
   crypto:
     dependency: transitive
     description:
@@ -119,7 +112,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   ffi:
     dependency: transitive
     description:
@@ -273,7 +266,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   lints:
     dependency: transitive
     description:
@@ -301,7 +294,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -378,7 +371,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   path_provider:
     dependency: "direct main"
     description:
@@ -579,7 +572,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -628,21 +621,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.19.5"
+    version: "1.21.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.13"
   typed_data:
     dependency: transitive
     description:
@@ -663,14 +656,14 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.5.0"
+    version: "8.2.2"
   watcher:
     dependency: transitive
     description:
@@ -721,5 +714,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.16.0 <3.0.0"
+  dart: ">=2.17.3 <3.0.0"
   flutter: ">=2.8.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: app_settings
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.1"
+    version: "4.1.8"
   archive:
     dependency: transitive
     description:
@@ -715,4 +715,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.17.3 <3.0.0"
-  flutter: ">=2.8.0"
+  flutter: ">=3.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -511,7 +511,7 @@ packages:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.27.3"
+    version: "0.27.4"
   sembast:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.4
+  cupertino_icons: ^1.0.5
 
   # The following dependency provides local persistence.
   sembast: ^3.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
   rxdart: ^0.27.3
 
   # This package provides platform independent file picking.
-  file_picker: ^4.5.0
+  file_picker: ^4.6.1
 
   # This package provides Bluetooth Low Energy functionality.
   flutter_blue_plus: ^1.1.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   jiffy: ^5.0.0
 
   # RxDart provides extensions to Dart Streams.
-  rxdart: ^0.27.3
+  rxdart: ^0.27.4
 
   # This package provides platform independent file picking.
   file_picker: ^4.6.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   sembast: ^3.2.0
 
   # For OS-specific directory paths.
-  path_provider: ^2.0.9
+  path_provider: ^2.0.11
   path: ^1.8.1
 
   # UUID generator for globally unique ids.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ description: The WeForza App
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.16.0 <3.0.0"
+  sdk: ">=2.17.3 <3.0.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,7 +56,7 @@ dependencies:
   app_settings: ^4.1.8
 
   # The permission_handler packages provides utilities for requesting permissions.
-  permission_handler: ^9.2.0
+  permission_handler: ^10.0.0
 
   # package_info_plus provides access to app specific information such as build number & version.
   package_info_plus: ^1.4.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
 
   # For OS-specific directory paths.
   path_provider: ^2.0.9
-  path: ^1.8.0
+  path: ^1.8.1
 
   # UUID generator for globally unique ids.
   uuid: ^3.0.6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   flutter_blue_plus: ^1.1.3
 
   # This package provides easy access to app settings.
-  app_settings: ^4.1.1
+  app_settings: ^4.1.8
 
   # The permission_handler packages provides utilities for requesting permissions.
   permission_handler: ^9.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   cupertino_icons: ^1.0.5
 
   # The following dependency provides local persistence.
-  sembast: ^3.2.0
+  sembast: ^3.2.0+1
 
   # For OS-specific directory paths.
   path_provider: ^2.0.11

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   file_picker: ^4.5.0
 
   # This package provides Bluetooth Low Energy functionality.
-  flutter_blue_plus: ^1.1.2
+  flutter_blue_plus: ^1.1.3
 
   # This package provides easy access to app settings.
   app_settings: ^4.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,7 +59,7 @@ dependencies:
   permission_handler: ^9.2.0
 
   # package_info_plus provides access to app specific information such as build number & version.
-  package_info_plus: ^1.4.0
+  package_info_plus: ^1.4.2
 
   file: ^6.1.2
 


### PR DESCRIPTION
This PR upgrades the project to Flutter 3.0

The remaining 15 warnings consist of lint warnings (and some open TODO's) that are still being addressed on the riverpod_providers branch.