### PR TITLE
Replace uses of `HashMap`

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -13,11 +13,10 @@ import 'package:weforza/database/database_factory.dart';
 class ApplicationDatabase {
   ApplicationDatabase({this.databaseName = 'weforza_database.db'});
 
-  // The name of the database file.
+  /// The name of the database file.
   final String databaseName;
 
-  // The internal instance of the database.
-  // We can assume that it is created before it is used.
+  /// The internal instance of the database.
   late Database _database;
 
   /// Get the database instance.

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -9,18 +9,18 @@ import 'package:sembast/sembast.dart';
 
 import 'package:weforza/database/database_factory.dart';
 
-///This class wraps a Sembast [Database] and datastore instances along with initializer and close methods.
+/// This class represents the application database.
 class ApplicationDatabase {
   ApplicationDatabase({this.databaseName = 'weforza_database.db'});
 
-  //The database filename.
+  // The name of the database file.
   final String databaseName;
 
   // The internal instance of the database.
   // We can assume that it is created before it is used.
   late Database _database;
 
-  ///Get the database instance.
+  /// Get the database instance.
   Database getDatabase() => _database;
 
   // TODO remove this method when migrated to new directory.
@@ -56,7 +56,7 @@ class ApplicationDatabase {
     }
   }
 
-  ///Initialize the database.
+  /// Open the database using the provided [databaseFactory].
   Future<void> openDatabase(ApplicationDatabaseFactory databaseFactory) async {
     final databaseDirectory = await getApplicationSupportDirectory();
     final dbPath = join(databaseDirectory.path, databaseName);
@@ -67,5 +67,6 @@ class ApplicationDatabase {
     _database = await databaseFactory.factory.openDatabase(dbPath);
   }
 
+  /// Close the database.
   void dispose() async => await _database.close();
 }

--- a/lib/database/database_factory.dart
+++ b/lib/database/database_factory.dart
@@ -2,11 +2,9 @@ import 'package:file/file.dart';
 import 'package:sembast/sembast.dart';
 
 class ApplicationDatabaseFactory {
-  ApplicationDatabaseFactory({
-    required this.fileSystem,
-    required this.factory,
-  });
+  ApplicationDatabaseFactory({required this.factory, required this.fileSystem});
+
+  final DatabaseFactory factory;
 
   final FileSystem fileSystem;
-  final DatabaseFactory factory;
 }

--- a/lib/database/device_dao.dart
+++ b/lib/database/device_dao.dart
@@ -1,5 +1,5 @@
 import 'package:sembast/sembast.dart';
-
+import 'package:weforza/database/database_tables.dart';
 import 'package:weforza/extensions/date_extension.dart';
 import 'package:weforza/model/device.dart';
 
@@ -44,7 +44,9 @@ abstract class DeviceDao {
 
 /// This class represents the default implementation of [DeviceDao].
 class DeviceDaoImpl implements DeviceDao {
-  DeviceDaoImpl(this._database, this._deviceStore, this._memberStore);
+  DeviceDaoImpl(this._database, DatabaseTables tables)
+      : _deviceStore = tables.device,
+        _memberStore = tables.member;
 
   /// A reference to the database.
   final Database _database;

--- a/lib/database/device_dao.dart
+++ b/lib/database/device_dao.dart
@@ -1,135 +1,109 @@
-import 'dart:collection';
-
 import 'package:sembast/sembast.dart';
 
 import 'package:weforza/extensions/date_extension.dart';
 import 'package:weforza/model/device.dart';
 
-///This interface defines a contract to work with member devices.
-abstract class IDeviceDao {
+/// This class defines an interface to work with devices.
+abstract class DeviceDao {
+  /// Add the given [device].
   Future<void> addDevice(Device device);
 
-  Future<void> removeDevice(Device device);
-
-  Future<void> updateDevice(Device newDevice);
-
-  Future<List<Device>> getOwnerDevices(String ownerId);
-
+  /// Check whether a device exists.
+  ///
+  /// If [creationDate] is null, this method returns whether a device exists
+  /// with the given [deviceName] and [ownerUuid].
+  ///
+  /// If [creationDate] is not null, this method returns whether a device exists
+  /// with the given [deviceName], [ownerUuid] and a creation date
+  /// that is *different* from the given creation date.
   Future<bool> deviceExists(
     String deviceName,
     String ownerUuid, [
     DateTime? creationDate,
   ]);
 
-  ///This groups all the devices together that belong to the same owner id.
-  ///Note that device names can occur in multiple lists, as multiple people can have a device with the same name.
-  Future<HashMap<String, Set<String>>> getAllDevicesGroupedByOwnerId();
-
+  /// Get the list of all devices.
   Future<List<Device>> getAllDevices();
+
+  /// Get the list of all devices and group them together on their [Device.ownerId].
+  ///
+  /// Returns a Map that contains the names of the devices per owner uuid.
+  /// A single device name can occur more than once in the entire map,
+  /// if multiple owners contain a device with the same name.
+  Future<Map<String, Set<String>>> getAllDevicesGroupedByOwnerId();
+
+  /// Get the devices of an [ownerId].
+  Future<List<Device>> getOwnerDevices(String ownerId);
+
+  /// Remove the given [device].
+  Future<void> removeDevice(Device device);
+
+  /// Update a device.
+  Future<void> updateDevice(Device newDevice);
 }
 
-///This class is an implementation of [IDeviceDao].
-class DeviceDao implements IDeviceDao {
-  DeviceDao(this._database, this._deviceStore, this._memberStore);
+/// This class represents the default implementation of [DeviceDao].
+class DeviceDaoImpl implements DeviceDao {
+  DeviceDaoImpl(this._database, this._deviceStore, this._memberStore);
 
-  ///A reference to the database, which is needed by the Store.
+  /// A reference to the database.
   final Database _database;
 
-  ///A reference to the device store.
+  /// A reference to the device store.
   final StoreRef<String, Map<String, dynamic>> _deviceStore;
 
-  ///A reference to the member store.
+  /// A reference to the member store.
   final StoreRef<String, Map<String, dynamic>> _memberStore;
 
+  /// Update the `lastUpdated` field of the owner of a given device.
+  Future<void> _updateOwnerLastUpdated(String ownerId, DatabaseClient txn) {
+    return _memberStore.record(ownerId).update(
+      txn,
+      {'lastUpdated': DateTime.now().toUtc().toStringWithoutMilliseconds()},
+    );
+  }
+
   @override
-  Future<void> addDevice(Device device) async {
-    await _database.transaction((txn) async {
+  Future<void> addDevice(Device device) {
+    return _database.transaction((txn) async {
       await _deviceStore
           .record(device.creationDate.toIso8601String())
           .add(txn, device.toMap());
-      await _memberStore.update(
-        txn,
-        {'lastUpdated': DateTime.now().toUtc().toStringWithoutMilliseconds()},
-        finder: Finder(
-          filter: Filter.byKey(device.ownerId),
-        ),
-      );
+
+      await _updateOwnerLastUpdated(device.ownerId, txn);
     });
   }
 
   @override
-  Future<List<Device>> getOwnerDevices(String ownerId) async {
-    final records = await _deviceStore.find(_database,
-        finder: Finder(filter: Filter.equals('owner', ownerId)));
-    return records
-        .map((record) => Device.of(record.key, record.value))
-        .toList();
+  Future<bool> deviceExists(
+    String deviceName,
+    String ownerUuid, [
+    DateTime? creationDate,
+  ]) async {
+    final finder = Finder(
+      filter: Filter.and([
+        Filter.equals('deviceName', deviceName),
+        Filter.equals('owner', ownerUuid),
+        if (creationDate != null)
+          Filter.notEquals(Field.key, creationDate.toIso8601String())
+      ]),
+    );
+
+    return await _deviceStore.findFirst(_database, finder: finder) != null;
   }
 
   @override
-  Future<void> removeDevice(Device device) async {
-    await _database.transaction((txn) async {
-      await _deviceStore.delete(
-        txn,
-        finder: Finder(
-          filter: Filter.and(<Filter>[
-            Filter.equals('deviceName', device.name),
-            Filter.equals('owner', device.ownerId),
-          ]),
-        ),
-      );
+  Future<List<Device>> getAllDevices() async {
+    final records = await _deviceStore.find(_database);
 
-      await _memberStore.update(
-        txn,
-        {'lastUpdated': DateTime.now().toUtc().toStringWithoutMilliseconds()},
-        finder: Finder(
-          filter: Filter.byKey(device.ownerId),
-        ),
-      );
-    });
+    return records.map((r) => Device.of(r.key, r.value)).toList();
   }
 
   @override
-  Future<void> updateDevice(Device newDevice) async {
-    await _database.transaction((txn) async {
-      await _deviceStore.update(txn, newDevice.toMap(),
-          finder: Finder(
-              filter: Filter.byKey(newDevice.creationDate.toIso8601String())));
-      await _memberStore.update(
-        txn,
-        {'lastUpdated': DateTime.now().toUtc().toStringWithoutMilliseconds()},
-        finder: Finder(
-          filter: Filter.byKey(newDevice.ownerId),
-        ),
-      );
-    });
-  }
+  Future<Map<String, Set<String>>> getAllDevicesGroupedByOwnerId() async {
+    final devices = await _deviceStore.find(_database);
 
-  @override
-  Future<bool> deviceExists(String deviceName, String ownerUuid,
-      [DateTime? creationDate]) async {
-    final List<Filter> filters = [
-      Filter.equals('deviceName', deviceName),
-      Filter.equals('owner', ownerUuid),
-      if (creationDate != null)
-        Filter.notEquals(Field.key, creationDate.toIso8601String())
-    ];
-
-    return await _deviceStore.findFirst(
-          _database,
-          finder: Finder(
-            filter: Filter.and(filters),
-          ),
-        ) !=
-        null;
-  }
-
-  @override
-  Future<HashMap<String, Set<String>>> getAllDevicesGroupedByOwnerId() async {
-    final List<RecordSnapshot<String, Map<String, dynamic>>> devices =
-        await _deviceStore.find(_database);
-
-    final HashMap<String, Set<String>> collection = HashMap();
+    final collection = <String, Set<String>>{};
 
     for (final record in devices) {
       final String device = record['deviceName'] as String;
@@ -146,10 +120,40 @@ class DeviceDao implements IDeviceDao {
   }
 
   @override
-  Future<List<Device>> getAllDevices() async {
-    final records = await _deviceStore.find(_database);
-    return records
-        .map((record) => Device.of(record.key, record.value))
-        .toList();
+  Future<List<Device>> getOwnerDevices(String ownerId) async {
+    final records = await _deviceStore.find(
+      _database,
+      finder: Finder(filter: Filter.equals('owner', ownerId)),
+    );
+
+    return records.map((r) => Device.of(r.key, r.value)).toList();
+  }
+
+  @override
+  Future<void> removeDevice(Device device) {
+    return _database.transaction((txn) async {
+      await _deviceStore.delete(
+        txn,
+        finder: Finder(
+          filter: Filter.and([
+            Filter.equals('deviceName', device.name),
+            Filter.equals('owner', device.ownerId),
+          ]),
+        ),
+      );
+
+      await _updateOwnerLastUpdated(device.ownerId, txn);
+    });
+  }
+
+  @override
+  Future<void> updateDevice(Device newDevice) {
+    return _database.transaction((txn) async {
+      final key = newDevice.creationDate.toIso8601String();
+
+      await _deviceStore.record(key).update(txn, newDevice.toMap());
+
+      await _updateOwnerLastUpdated(newDevice.ownerId, txn);
+    });
   }
 }

--- a/lib/database/export_rides_dao.dart
+++ b/lib/database/export_rides_dao.dart
@@ -1,4 +1,5 @@
 import 'package:sembast/sembast.dart';
+import 'package:weforza/database/database_tables.dart';
 import 'package:weforza/model/exportable_ride.dart';
 import 'package:weforza/model/member.dart';
 import 'package:weforza/model/ride.dart';
@@ -14,10 +15,10 @@ abstract class ExportRidesDao {
 class ExportRidesDaoImpl implements ExportRidesDao {
   ExportRidesDaoImpl(
     this._database,
-    this._memberStore,
-    this._rideAttendeeStore,
-    this._rideStore,
-  );
+    DatabaseTables tables,
+  )   : _memberStore = tables.member,
+        _rideAttendeeStore = tables.rideAttendee,
+        _rideStore = tables.ride;
 
   /// A reference to the database, which is needed by the Store.
   final Database _database;

--- a/lib/database/export_rides_dao.dart
+++ b/lib/database/export_rides_dao.dart
@@ -20,7 +20,7 @@ class ExportRidesDaoImpl implements ExportRidesDao {
         _rideAttendeeStore = tables.rideAttendee,
         _rideStore = tables.ride;
 
-  /// A reference to the database, which is needed by the Store.
+  /// A reference to the database.
   final Database _database;
 
   /// A reference to the [Member] store.

--- a/lib/database/import_members_dao.dart
+++ b/lib/database/import_members_dao.dart
@@ -1,5 +1,3 @@
-import 'dart:collection';
-
 import 'package:sembast/sembast.dart';
 import 'package:weforza/model/device.dart';
 import 'package:weforza/model/exportable_member.dart';
@@ -68,10 +66,10 @@ class ImportMembersDao implements IImportMembersDao {
     // With this collection we can check
     // if a given member is an existing one or not.
     // We can also retrieve properties of the existing member easily.
-    final Map<ImportableMemberKey, Member> existingMembers = HashMap();
+    final existingMembers = <ImportableMemberKey, Member>{};
     // This Map holds the existing devices per member uuid.
     // We can only filter on the name of the device.
-    final Map<String, Set<String>> existingDevices = HashMap();
+    final existingDevices = <String, Set<String>>{};
     // This set holds the members that are scheduled for an update.
     final Set<ImportableMember> membersToUpdate = {};
     // This set holds the members that are scheduled for insertion.

--- a/lib/database/member_dao.dart
+++ b/lib/database/member_dao.dart
@@ -1,30 +1,33 @@
 import 'package:sembast/sembast.dart';
+import 'package:weforza/database/database_tables.dart';
 
 import 'package:weforza/extensions/date_extension.dart';
 import 'package:weforza/model/member.dart';
 import 'package:weforza/model/member_filter_option.dart';
 import 'package:weforza/model/ride_attendee.dart';
 
-///This interface defines a contract to manipulate [Member]s in persistent storage.
-abstract class IMemberDao {
-  ///Add a [Member] to the database.
+/// This class defines an interface to work with members.
+abstract class MemberDao {
+  /// Add a [member].
   Future<void> addMember(Member member);
 
-  ///Delete a [Member] from the database.
+  /// Delete the member with the given [uuid].
   Future<void> deleteMember(String uuid);
 
-  ///Update a [Member].
-  Future<void> updateMember(Member member);
+  /// Get the amount of rides that a member with the given [uuid] has attended.
+  Future<int> getAttendingCount(String uuid);
 
-  ///Get the [Member]s, using the given [MemberFilterOption].
-  Future<List<Member>> getMembers(MemberFilterOption filterOption);
+  /// Get the list of members that satisfy the given [filter].
+  Future<List<Member>> getMembers(MemberFilterOption filter);
 
-  ///Check if a [Member] with the given values exists.
-  ///If [uuid] is null or empty, it checks whether there is a member with the given values.
+  /// Check whether a member exists.
   ///
-  ///If [uuid] isn't null or empty it checks if there is a member with the values and a uuid that is different from [uuid].
-  ///A member with the same values and uuid means it's the owner of said values.
-  ///This would merely overwrite the old one with a copy of itself and is thus harmless.
+  /// If [uuid] is null, this method returns whether a member exists
+  /// with the given [firstname], [lastname] and [alias].
+  ///
+  /// If [uuid] is not null, this method returns whether a member exists
+  /// with the given [firstname], [lastname], [alias] and a uuid
+  /// that is *different* from the given uuid.
   Future<bool> memberExists(
     String firstname,
     String lastname,
@@ -32,33 +35,32 @@ abstract class IMemberDao {
     String? uuid,
   ]);
 
-  ///Get the number of rides a [Member] with the given id attended.
-  Future<int> getAttendingCountForAttendee(String uuid);
-
-  /// Set the active state for a given member to the new value.
+  /// Toggle the active state of the member with the given [uuid].
   Future<void> setMemberActive(String uuid, bool value);
+
+  /// Update the given [member].
+  Future<void> updateMember(Member member);
 }
 
-///This class is an implementation of [IMemberDao].
-class MemberDao implements IMemberDao {
-  MemberDao(
-    this._database,
-    this._memberStore,
-    this._rideAttendeeStore,
-    this._deviceStore,
-  );
+/// This class represents the default implementation of [MemberDao].
+class MemberDaoImpl implements MemberDao {
+  /// The default constructor.
+  MemberDaoImpl(this._database, DatabaseTables tables)
+      : _deviceStore = tables.device,
+        _memberStore = tables.member,
+        _rideAttendeeStore = tables.rideAttendee;
 
-  ///A reference to the application database.
+  /// A reference to the database.
   final Database _database;
 
-  ///A reference to the [Member] store.
+  /// A reference to the [Device] store.
+  final StoreRef<String, Map<String, dynamic>> _deviceStore;
+
+  /// A reference to the [Member] store.
   final StoreRef<String, Map<String, dynamic>> _memberStore;
 
-  ///A reference to the [RideAttendee] store.
+  /// A reference to the [RideAttendee] store.
   final StoreRef<String, Map<String, dynamic>> _rideAttendeeStore;
-
-  ///A reference to the [Device] store.
-  final StoreRef<String, Map<String, dynamic>> _deviceStore;
 
   @override
   Future<void> addMember(Member member) async {
@@ -87,14 +89,24 @@ class MemberDao implements IMemberDao {
   }
 
   @override
-  Future<List<Member>> getMembers(MemberFilterOption filterOption) async {
-    final Finder finder = Finder(sortOrders: [
-      SortOrder('firstname'),
-      SortOrder('lastname'),
-      SortOrder('alias')
-    ]);
+  Future<int> getAttendingCount(String uuid) {
+    return _rideAttendeeStore.count(
+      _database,
+      filter: Filter.equals('attendee', uuid),
+    );
+  }
 
-    switch (filterOption) {
+  @override
+  Future<List<Member>> getMembers(MemberFilterOption filter) async {
+    final finder = Finder(
+      sortOrders: [
+        SortOrder('firstname'),
+        SortOrder('lastname'),
+        SortOrder('alias'),
+      ],
+    );
+
+    switch (filter) {
       case MemberFilterOption.active:
         finder.filter = Filter.equals('active', true);
         break;
@@ -105,27 +117,24 @@ class MemberDao implements IMemberDao {
         break;
     }
 
-    final Iterable<Member> members =
-        await _memberStore.find(_database, finder: finder).then((records) {
-      return records.map((record) => Member.of(record.key, record.value));
-    });
+    final records = await _memberStore.find(_database, finder: finder);
 
-    return members.toList();
+    return records.map((r) => Member.of(r.key, r.value)).toList();
   }
 
   @override
-  Future<void> updateMember(Member member) {
-    return _memberStore.record(member.uuid).update(_database, member.toMap());
-  }
-
-  @override
-  Future<bool> memberExists(String firstname, String lastname, String alias,
-      [String? uuid]) async {
-    final List<Filter> filters = [
+  Future<bool> memberExists(
+    String firstname,
+    String lastname,
+    String alias, [
+    String? uuid,
+  ]) async {
+    final filters = [
       Filter.equals('firstname', firstname),
       Filter.equals('lastname', lastname),
       Filter.equals('alias', alias),
     ];
+
     if (uuid != null && uuid.isNotEmpty) {
       filters.add(Filter.notEquals(Field.key, uuid));
     }
@@ -136,20 +145,22 @@ class MemberDao implements IMemberDao {
   }
 
   @override
-  Future<int> getAttendingCountForAttendee(String uuid) {
-    return _rideAttendeeStore.count(_database,
-        filter: Filter.equals('attendee', uuid));
-  }
-
-  @override
   Future<void> setMemberActive(String uuid, bool value) async {
     final record = _memberStore.record(uuid);
 
     if (await record.exists(_database)) {
-      await record.update(_database, {
-        'active': value,
-        'lastUpdated': DateTime.now().toUtc().toStringWithoutMilliseconds()
-      });
+      await record.update(
+        _database,
+        {
+          'active': value,
+          'lastUpdated': DateTime.now().toUtc().toStringWithoutMilliseconds()
+        },
+      );
     }
+  }
+
+  @override
+  Future<void> updateMember(Member member) {
+    return _memberStore.record(member.uuid).update(_database, member.toMap());
   }
 }

--- a/lib/database/ride_dao.dart
+++ b/lib/database/ride_dao.dart
@@ -1,55 +1,55 @@
 import 'package:sembast/sembast.dart';
+import 'package:weforza/database/database_tables.dart';
 import 'package:weforza/model/member.dart';
 import 'package:weforza/model/ride.dart';
 import 'package:weforza/model/ride_attendee.dart';
 import 'package:weforza/model/ride_attendee_scanning/scanned_ride_attendee.dart';
 
-/// This interface provides a contract for manipulating [Ride]s in persistent storage.
-abstract class IRideDao {
-  /// Add rides to the database.
+/// This class represents an interface for working with rides.
+abstract class RideDao {
+  /// Add the given [rides].
   Future<void> addRides(List<Ride> rides);
 
-  /// Delete a ride with the given ride date.
+  /// Delete the ride with the given [date].
   Future<void> deleteRide(DateTime date);
 
-  /// Delete all rides & attendant records.
+  /// Delete the entire ride calendar.
   Future<void> deleteRideCalendar();
 
-  /// Get the current amount of rides.
-  Future<int> getCurrentRideCount();
-
-  /// Get all rides. This method will load all the stored [Ride]s
-  /// and populate their attendee count.
-  Future<List<Ride>> getRides();
-
-  /// Get a stream of changes to the amount of rides.
-  Stream<int> getRideCount();
-
-  /// Update the scanned attendees counter and attendees list for the given ride.
-  Future<void> updateRide(Ride ride, List<RideAttendee> attendees);
-
-  /// Get the dates of the existing rides.
-  Future<List<DateTime>> getRideDates();
-
-  /// Get the [Member]s of a given ride.
+  /// Get the attendees of the ride with the given [date].
   Future<List<Member>> getRideAttendees(DateTime date);
 
-  /// Get the attendees of the ride, converted to [ScannedRideAttendee]s.
-  Future<List<ScannedRideAttendee>> getRideAttendeesAsScanResults(
-    DateTime date,
-  );
+  /// Get the dates of the rides in the calendar.
+  Future<List<DateTime>> getRideDates();
+
+  /// Get the list of rides.
+  Future<List<Ride>> getRides();
+
+  /// Get the amount of rides in the calendar.
+  Future<int> getRidesCount();
+
+  /// Get the attendees of the ride with the given [date], as scan results.
+  Future<List<ScannedRideAttendee>> getScanResults(DateTime date);
+
+  /// Update the given [ride] and its [attendees].
+  Future<void> updateRide(Ride ride, List<RideAttendee> attendees);
+
+  /// Get a stream of changes to the amount of rides.
+  Stream<int> watchRidesCount();
 }
 
-class RideDao implements IRideDao {
-  RideDao(
-    this._database,
-    this._memberStore,
-    this._rideStore,
-    this._rideAttendeeStore,
-  );
+/// The default implementation of [RideDao].
+class RideDaoImpl implements RideDao {
+  RideDaoImpl(this._database, DatabaseTables tables)
+      : _memberStore = tables.member,
+        _rideAttendeeStore = tables.rideAttendee,
+        _rideStore = tables.ride;
 
   /// A reference to the database.
   final Database _database;
+
+  /// A reference to the [Member] store.
+  final StoreRef<String, Map<String, dynamic>> _memberStore;
 
   /// A reference to the [RideAttendee] store.
   final StoreRef<String, Map<String, dynamic>> _rideAttendeeStore;
@@ -57,22 +57,13 @@ class RideDao implements IRideDao {
   /// A reference to the [Ride] store.
   final StoreRef<String, Map<String, dynamic>> _rideStore;
 
-  /// A reference to the [Member] store.
-  final StoreRef<String, Map<String, dynamic>> _memberStore;
-
   @override
   Future<void> addRides(List<Ride> rides) async {
-    await _rideStore
-        .records(rides.map((r) => r.date.toIso8601String()).toList())
-        .put(_database, rides.map((r) => r.toMap()).toList());
-  }
+    final records = _rideStore.records(
+      rides.map((r) => r.date.toIso8601String()).toList(),
+    );
 
-  @override
-  Future<void> deleteRideCalendar() {
-    return _database.transaction((txn) async {
-      await _rideAttendeeStore.delete(txn);
-      await _rideStore.delete(txn);
-    });
+    await records.put(_database, rides.map((r) => r.toMap()).toList());
   }
 
   @override
@@ -90,70 +81,86 @@ class RideDao implements IRideDao {
   }
 
   @override
-  Future<int> getCurrentRideCount() => _rideStore.count(_database);
-
-  @override
-  Future<List<Ride>> getRides() async {
-    final rideRecords = await _rideStore.find(
-      _database,
-      finder: Finder(sortOrders: [SortOrder(Field.key, false)]),
-    );
-
-    return rideRecords
-        .map((record) => Ride.of(DateTime.parse(record.key), record.value))
-        .toList();
-  }
-
-  @override
-  Stream<int> getRideCount() => _rideStore.onCount(_database);
-
-  @override
-  Future<List<DateTime>> getRideDates() async {
-    final rides = await _rideStore.findKeys(_database);
-    return rides.map((ride) => DateTime.parse(ride)).toList();
+  Future<void> deleteRideCalendar() {
+    return _database.transaction((txn) async {
+      await _rideAttendeeStore.delete(txn);
+      await _rideStore.delete(txn);
+    });
   }
 
   @override
   Future<List<Member>> getRideAttendees(DateTime date) async {
-    final rideAttendeeRecords = await _rideAttendeeStore.find(
+    final rideAttendees = await _rideAttendeeStore.find(
       _database,
       finder: Finder(filter: Filter.equals('date', date.toIso8601String())),
     );
 
-    final attendeeIds =
-        rideAttendeeRecords.map((record) => record.value['attendee']).toList();
+    final attendeeIds = rideAttendees.map((r) => r.value['attendee']).toList();
 
     final memberRecords = await _memberStore.find(
       _database,
       finder: Finder(
         filter: Filter.custom((record) => attendeeIds.contains(record.key)),
-        sortOrders: [SortOrder('firstname'), SortOrder('lastname')],
+        sortOrders: [
+          SortOrder('firstname'),
+          SortOrder('lastname'),
+          SortOrder('alias'),
+        ],
       ),
     );
 
-    return memberRecords
-        .map((record) => Member.of(record.key, record.value))
-        .toList();
+    return memberRecords.map((r) => Member.of(r.key, r.value)).toList();
+  }
+
+  @override
+  Future<List<DateTime>> getRideDates() async {
+    final rides = await _rideStore.findKeys(_database);
+
+    return rides.map(DateTime.parse).toList();
+  }
+
+  @override
+  Future<List<Ride>> getRides() async {
+    final records = await _rideStore.find(
+      _database,
+      finder: Finder(sortOrders: [SortOrder(Field.key, false)]),
+    );
+
+    return records.map((r) => Ride.of(DateTime.parse(r.key), r.value)).toList();
+  }
+
+  @override
+  Future<int> getRidesCount() => _rideStore.count(_database);
+
+  @override
+  Future<List<ScannedRideAttendee>> getScanResults(DateTime date) async {
+    final records = await _rideAttendeeStore.find(
+      _database,
+      finder: Finder(filter: Filter.equals('date', date.toIso8601String())),
+    );
+
+    return records.map((r) => ScannedRideAttendee.of(r.value)).toList();
   }
 
   @override
   Future<void> updateRide(Ride ride, List<RideAttendee> attendees) {
-    // The key for the ride record is the ride date as an ISO 8601 date string.
+    // The key for the ride record is the ride date as an ISO 8601 date.
     final rideRecordKey = ride.date.toIso8601String();
-    // Find the attendees that have the ride record key as date field.
-    final rideAttendeeFinder =
-        Finder(filter: Filter.equals('date', rideRecordKey));
+
+    // Find the attendees for the ride.
+    final rideAttendeeFinder = Finder(
+      filter: Filter.equals('date', rideRecordKey),
+    );
 
     return _database.transaction((txn) async {
       // Update the ride scanned attendees counter in the record.
       await _rideStore.record(rideRecordKey).update(txn, ride.toMap());
 
-      // To update the attendees for the given ride we do the following:
-      // - Clear all the old ones
-      // - Insert the given attendees (both old and new)
+      // Delete the old attendees for the ride and insert all the new attendees,
+      // which are both the old records and the new records.
       await _rideAttendeeStore.delete(txn, finder: rideAttendeeFinder);
-      // The attendees use the ride record key concatenated with their own UUID
-      // as own database record key.
+      // Each attendee record uses the ride record key
+      // concatenated with the uuid as record key.
       await _rideAttendeeStore
           .records(attendees.map((a) => '$rideRecordKey${a.uuid}'))
           .put(txn, attendees.map((a) => a.toMap()).toList());
@@ -161,16 +168,5 @@ class RideDao implements IRideDao {
   }
 
   @override
-  Future<List<ScannedRideAttendee>> getRideAttendeesAsScanResults(
-    DateTime date,
-  ) async {
-    final rideAttendeeRecords = await _rideAttendeeStore.find(
-      _database,
-      finder: Finder(filter: Filter.equals('date', date.toIso8601String())),
-    );
-
-    return rideAttendeeRecords
-        .map((record) => ScannedRideAttendee.of(record.value))
-        .toList();
-  }
+  Stream<int> watchRidesCount() => _rideStore.onCount(_database);
 }

--- a/lib/database/ride_dao.dart
+++ b/lib/database/ride_dao.dart
@@ -68,8 +68,8 @@ class RideDao implements IRideDao {
   }
 
   @override
-  Future<void> deleteRideCalendar() async {
-    await _database.transaction((txn) async {
+  Future<void> deleteRideCalendar() {
+    return _database.transaction((txn) async {
       await _rideAttendeeStore.delete(txn);
       await _rideStore.delete(txn);
     });
@@ -137,14 +137,14 @@ class RideDao implements IRideDao {
   }
 
   @override
-  Future<void> updateRide(Ride ride, List<RideAttendee> attendees) async {
+  Future<void> updateRide(Ride ride, List<RideAttendee> attendees) {
     // The key for the ride record is the ride date as an ISO 8601 date string.
     final rideRecordKey = ride.date.toIso8601String();
     // Find the attendees that have the ride record key as date field.
     final rideAttendeeFinder =
         Finder(filter: Filter.equals('date', rideRecordKey));
 
-    await _database.transaction((txn) async {
+    return _database.transaction((txn) async {
       // Update the ride scanned attendees counter in the record.
       await _rideStore.record(rideRecordKey).update(txn, ride.toMap());
 

--- a/lib/database/ride_dao.dart
+++ b/lib/database/ride_dao.dart
@@ -76,14 +76,16 @@ class RideDao implements IRideDao {
   }
 
   @override
-  Future<void> deleteRide(DateTime date) async {
+  Future<void> deleteRide(DateTime date) {
     final isoDate = date.toIso8601String();
-    final rideFinder = Finder(filter: Filter.byKey(isoDate));
-    final rideAttendeeFinder = Finder(filter: Filter.equals('date', isoDate));
 
-    await _database.transaction((txn) async {
-      await _rideAttendeeStore.delete(txn, finder: rideAttendeeFinder);
-      await _rideStore.delete(txn, finder: rideFinder);
+    return _database.transaction((txn) async {
+      await _rideAttendeeStore.delete(
+        txn,
+        finder: Finder(filter: Filter.equals('date', isoDate)),
+      );
+
+      await _rideStore.record(isoDate).delete(txn);
     });
   }
 

--- a/lib/extensions/date_extension.dart
+++ b/lib/extensions/date_extension.dart
@@ -1,10 +1,10 @@
 extension ToStringNoMillis on DateTime {
-  /// Convert the given date to a 'YYYY-MM-DD HH:MM:SSZ' string.
-  /// E.g. 1969-07-20 20:18:04Z
+  /// Convert the given date to a 'YYYY-MM-DD HH:MM:SS' string.
+  /// E.g. 1969-07-20 20:18:04
   String toStringWithoutMilliseconds() {
     final String s = toString();
 
-    // Strip the milliseconds and append a Z.
-    return '${s.substring(0, s.length - 5)}Z';
+    // Strip the milliseconds.
+    return s.substring(0, s.length - 5);
   }
 }

--- a/lib/file/csv_file_reader.dart
+++ b/lib/file/csv_file_reader.dart
@@ -80,7 +80,7 @@ class CsvFileReader implements ImportMembersFileReader<String> {
       firstName: firstName,
       lastName: lastName,
       alias: alias,
-      isActiveMember: isActive,
+      active: isActive,
       devices: devices,
       lastUpdated: lastUpdated,
     ));

--- a/lib/file/file_handler.dart
+++ b/lib/file/file_handler.dart
@@ -25,7 +25,7 @@ enum FileExtension {
 }
 
 /// This interface provides methods to work with [File]s.
-abstract class IFileHandler {
+abstract class FileHandler {
   /// Pick a profile image from the device gallery.
   /// Returns the [File] that was chosen.
   Future<File?> chooseProfileImageFromGallery();
@@ -42,8 +42,8 @@ abstract class IFileHandler {
   Future<File> createFile(String fileName, String extension);
 }
 
-/// The default implementation of [IFileHandler].
-class FileHandler implements IFileHandler {
+/// The default implementation of [FileHandler].
+class IoFileHandler implements FileHandler {
   @override
   Future<File?> chooseProfileImageFromGallery() async {
     final result = await FilePicker.platform.pickFiles(type: FileType.image);

--- a/lib/file/json_file_reader.dart
+++ b/lib/file/json_file_reader.dart
@@ -40,7 +40,7 @@ class JsonFileReader implements ImportMembersFileReader<Map<String, dynamic>> {
         firstName: firstName,
         lastName: lastName,
         alias: alias,
-        isActiveMember: isActive,
+        active: isActive,
         devices: deviceNames
             .where((deviceName) => Device.deviceNameRegex.hasMatch(deviceName))
             .toSet(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,9 +27,9 @@ void main() async {
 
   // Preload the settings.
   final settingsRepository = SettingsRepository(
-    SettingsDao(database.getDatabase(), DatabaseTables().settings),
+    SettingsDaoImpl(database.getDatabase(), DatabaseTables()),
   );
-  final settings = await settingsRepository.loadApplicationSettings();
+  final settings = await settingsRepository.read();
 
   // Preload the package info.
   final packageInfo = await PackageInfo.fromPlatform();

--- a/lib/model/exportable_member.dart
+++ b/lib/model/exportable_member.dart
@@ -1,4 +1,5 @@
 import 'package:weforza/extensions/date_extension.dart';
+import 'package:weforza/model/importable_member.dart';
 
 /// This class represents an exportable member.
 ///
@@ -32,6 +33,15 @@ class ExportableMember {
 
   /// The timestamp that indicates the last update of this member.
   final DateTime lastUpdated;
+
+  /// Get the import key for this importable member.
+  ImportableMemberKey get importKey {
+    return ImportableMemberKey(
+      alias: alias,
+      firstName: firstName,
+      lastName: lastName,
+    );
+  }
 
   /// Convert this object to a comma separated string.
   String toCsv() {

--- a/lib/model/exportable_member.dart
+++ b/lib/model/exportable_member.dart
@@ -1,38 +1,58 @@
 import 'package:weforza/extensions/date_extension.dart';
 
-/// This class is used as format for exporting members.
+/// This class represents an exportable member.
+///
+/// It is used for exporting members as well as importing members,
+/// since the format should be interchangeable.
 class ExportableMember {
+  /// The default constructor.
   ExportableMember({
+    required this.active,
+    required this.alias,
+    required this.devices,
     required this.firstName,
     required this.lastName,
-    required this.alias,
-    required this.isActiveMember,
-    required this.devices,
     required this.lastUpdated,
   }) : assert(firstName.isNotEmpty && lastName.isNotEmpty);
 
-  final bool isActiveMember;
-  final String firstName;
-  final String lastName;
+  /// Whether this member is an active member.
+  final bool active;
+
+  /// The alias of the member.
   final String alias;
+
+  /// The names of the devices that this member owns.
   final Set<String> devices;
+
+  /// The first name of the member.
+  final String firstName;
+
+  /// The last name of the member.
+  final String lastName;
+
+  /// The timestamp that indicates the last update of this member.
   final DateTime lastUpdated;
 
+  /// Convert this object to a comma separated string.
   String toCsv() {
-    final String devicesString = devices.isEmpty ? '' : devices.join(',');
+    final sb = StringBuffer('$firstName,$lastName,$alias,');
 
-    return '$firstName,$lastName,$alias,${isActiveMember ? 1 : 0},'
-        '${lastUpdated.toStringWithoutMilliseconds()},$devicesString';
+    sb.write('${active ? 1 : 0},');
+    sb.write('${lastUpdated.toStringWithoutMilliseconds()},');
+    sb.write(devices.isEmpty ? '' : devices.join(','));
+
+    return sb.toString();
   }
 
+  /// Convert this object to JSON.
   Map<String, Object?> toJson() {
     return {
+      'active': active,
+      'alias': alias,
+      'devices': devices.toList(),
       'firstName': firstName,
       'lastName': lastName,
-      'alias': alias,
-      'active': isActiveMember,
       'lastUpdated': lastUpdated.toStringWithoutMilliseconds(),
-      'devices': devices.toList(),
     };
   }
 }

--- a/lib/model/profile_image_picker_delegate.dart
+++ b/lib/model/profile_image_picker_delegate.dart
@@ -17,7 +17,7 @@ class ProfileImagePickerDelegate {
         );
 
   /// The file handler for this delegate.
-  final IFileHandler fileHandler;
+  final FileHandler fileHandler;
 
   final BehaviorSubject<SelectProfileImageState> _imageController;
 

--- a/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
+++ b/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
@@ -197,7 +197,7 @@ class RideAttendeeScanningDelegate {
 
   /// Get the attendees of the [ride].
   Future<void> _loadRideAttendees() async {
-    final items = await rideRepository.getRideAttendeesAsScanResults(ride.date);
+    final items = await rideRepository.getScanResults(ride.date);
 
     if (_rideAttendeeController.isClosed) {
       return;

--- a/lib/repository/device_repository.dart
+++ b/lib/repository/device_repository.dart
@@ -4,20 +4,25 @@ import 'package:weforza/model/device.dart';
 class DeviceRepository {
   DeviceRepository(this._dao);
 
-  final IDeviceDao _dao;
+  final DeviceDao _dao;
 
   Future<void> addDevice(Device device) => _dao.addDevice(device);
+
+  Future<bool> deviceExists(
+    String deviceName,
+    String ownerUuid, [
+    DateTime? creationDate,
+  ]) {
+    return _dao.deviceExists(deviceName, ownerUuid, creationDate);
+  }
+
+  Future<List<Device>> getAllDevices() => _dao.getAllDevices();
+
+  Future<List<Device>> getOwnerDevices(String uuid) {
+    return _dao.getOwnerDevices(uuid);
+  }
 
   Future<void> removeDevice(Device device) => _dao.removeDevice(device);
 
   Future<void> updateDevice(Device newDevice) => _dao.updateDevice(newDevice);
-
-  Future<List<Device>> getOwnerDevices(String uuid) =>
-      _dao.getOwnerDevices(uuid);
-
-  Future<bool> deviceExists(String deviceName, String ownerUuid,
-          [DateTime? creationDate]) =>
-      _dao.deviceExists(deviceName, ownerUuid, creationDate);
-
-  Future<List<Device>> getAllDevices() => _dao.getAllDevices();
 }

--- a/lib/repository/export_members_repository.dart
+++ b/lib/repository/export_members_repository.dart
@@ -21,7 +21,7 @@ class ExportMembersRepository {
         firstName: member.firstname,
         lastName: member.lastname,
         alias: member.alias,
-        isActiveMember: member.isActiveMember,
+        active: member.isActiveMember,
         devices: devices[member.uuid] ?? <String>{},
         lastUpdated: member.lastUpdated,
       ),

--- a/lib/repository/export_members_repository.dart
+++ b/lib/repository/export_members_repository.dart
@@ -1,36 +1,30 @@
-import 'dart:collection';
-
 import 'package:weforza/database/device_dao.dart';
 import 'package:weforza/database/member_dao.dart';
 import 'package:weforza/model/exportable_member.dart';
-import 'package:weforza/model/member.dart';
 import 'package:weforza/model/member_filter_option.dart';
 
 class ExportMembersRepository {
   ExportMembersRepository(this.deviceDao, this.memberDao);
 
-  final IDeviceDao deviceDao;
+  final DeviceDao deviceDao;
   final IMemberDao memberDao;
 
-  Future<void> _getDevices(HashMap<String, Set<String>> collection) async =>
-      collection.addAll(await deviceDao.getAllDevicesGroupedByOwnerId());
-  Future<void> _getMembers(List<Member> collection) async =>
-      collection.addAll(await memberDao.getMembers(MemberFilterOption.all));
-
   Future<Iterable<ExportableMember>> getMembers() async {
-    final HashMap<String, Set<String>> devicesGroupedByOwner = HashMap();
-    final List<Member> members = [];
+    final membersFuture = memberDao.getMembers(MemberFilterOption.all);
+    final devicesFuture = deviceDao.getAllDevicesGroupedByOwnerId();
 
-    await Future.wait(
-        [_getDevices(devicesGroupedByOwner), _getMembers(members)]);
+    final members = await membersFuture;
+    final devices = await devicesFuture;
 
-    return members.map((member) => ExportableMember(
-          firstName: member.firstname,
-          lastName: member.lastname,
-          alias: member.alias,
-          isActiveMember: member.isActiveMember,
-          devices: devicesGroupedByOwner[member.uuid] ?? <String>{},
-          lastUpdated: member.lastUpdated,
-        ));
+    return members.map(
+      (member) => ExportableMember(
+        firstName: member.firstname,
+        lastName: member.lastname,
+        alias: member.alias,
+        isActiveMember: member.isActiveMember,
+        devices: devices[member.uuid] ?? <String>{},
+        lastUpdated: member.lastUpdated,
+      ),
+    );
   }
 }

--- a/lib/repository/export_members_repository.dart
+++ b/lib/repository/export_members_repository.dart
@@ -7,7 +7,7 @@ class ExportMembersRepository {
   ExportMembersRepository(this.deviceDao, this.memberDao);
 
   final DeviceDao deviceDao;
-  final IMemberDao memberDao;
+  final MemberDao memberDao;
 
   Future<Iterable<ExportableMember>> getMembers() async {
     final membersFuture = memberDao.getMembers(MemberFilterOption.all);

--- a/lib/repository/export_rides_repository.dart
+++ b/lib/repository/export_rides_repository.dart
@@ -4,7 +4,7 @@ import 'package:weforza/model/exportable_ride.dart';
 class ExportRidesRepository {
   ExportRidesRepository(this.dao);
 
-  final IExportRidesDao dao;
+  final ExportRidesDao dao;
 
   Future<Iterable<ExportableRide>> getRides(DateTime? ride) {
     return dao.getRides(ride);

--- a/lib/repository/import_members_repository.dart
+++ b/lib/repository/import_members_repository.dart
@@ -4,9 +4,9 @@ import 'package:weforza/model/exportable_member.dart';
 class ImportMembersRepository {
   ImportMembersRepository(this.dao);
 
-  final IImportMembersDao dao;
+  final ImportMembersDao dao;
 
-  Future<void> saveMembersWithDevices(
-          Iterable<ExportableMember> members, String Function() generateId) =>
-      dao.saveMembersWithDevices(members, generateId);
+  Future<void> saveMembersWithDevices(Iterable<ExportableMember> members) {
+    return dao.saveMembersWithDevices(members);
+  }
 }

--- a/lib/repository/member_repository.dart
+++ b/lib/repository/member_repository.dart
@@ -4,29 +4,34 @@ import 'package:weforza/database/member_dao.dart';
 import 'package:weforza/model/member.dart';
 import 'package:weforza/model/member_filter_option.dart';
 
-///This class provides an API to work with members.
+/// This class provides an API to work with members.
 class MemberRepository {
   MemberRepository(this._dao);
 
-  ///The internal DAO instance.
-  final IMemberDao _dao;
+  final MemberDao _dao;
 
   Future<void> addMember(Member member) => _dao.addMember(member);
 
-  Future<List<Member>> getMembers(MemberFilterOption filter) =>
-      _dao.getMembers(filter);
-
-  Future<bool> memberExists(String firstname, String lastname, String alias,
-          [String? uuid]) =>
-      _dao.memberExists(firstname, lastname, alias, uuid);
-
   Future<void> deleteMember(String uuid) => _dao.deleteMember(uuid);
 
+  Future<int> getAttendingCount(String uuid) => _dao.getAttendingCount(uuid);
+
+  Future<List<Member>> getMembers(MemberFilterOption filter) {
+    return _dao.getMembers(filter);
+  }
+
+  Future<bool> memberExists(
+    String firstname,
+    String lastname,
+    String alias, [
+    String? uuid,
+  ]) {
+    return _dao.memberExists(firstname, lastname, alias, uuid);
+  }
+
+  Future<void> setMemberActive(String uuid, bool value) {
+    return _dao.setMemberActive(uuid, value);
+  }
+
   Future<void> updateMember(Member member) => _dao.updateMember(member);
-
-  Future<int> getAttendingCountForAttendee(String uuid) =>
-      _dao.getAttendingCountForAttendee(uuid);
-
-  Future<void> setMemberActive(String uuid, bool value) =>
-      _dao.setMemberActive(uuid, value);
 }

--- a/lib/repository/ride_repository.dart
+++ b/lib/repository/ride_repository.dart
@@ -8,7 +8,7 @@ import 'package:weforza/model/ride_attendee_scanning/scanned_ride_attendee.dart'
 class RideRepository {
   RideRepository(this._dao);
 
-  final IRideDao _dao;
+  final RideDao _dao;
 
   Future<void> addRides(List<Ride> rides) => _dao.addRides(rides);
 
@@ -16,25 +16,23 @@ class RideRepository {
 
   Future<void> deleteRideCalendar() => _dao.deleteRideCalendar();
 
-  Future<int> getCurrentRideCount() => _dao.getCurrentRideCount();
+  Future<List<Member>> getRideAttendees(DateTime date) {
+    return _dao.getRideAttendees(date);
+  }
 
-  Stream<int> getRideCount() => _dao.getRideCount();
+  Future<List<DateTime>> getRideDates() => _dao.getRideDates();
 
   Future<List<Ride>> getRides() => _dao.getRides();
 
-  Future<List<DateTime>> getRideDates() => _dao.getRideDates();
+  Future<int> getRidesCount() => _dao.getRidesCount();
+
+  Future<List<ScannedRideAttendee>> getScanResults(DateTime date) {
+    return _dao.getScanResults(date);
+  }
 
   Future<void> updateRide(Ride ride, List<RideAttendee> attendees) {
     return _dao.updateRide(ride, attendees);
   }
 
-  Future<List<Member>> getRideAttendees(DateTime date) {
-    return _dao.getRideAttendees(date);
-  }
-
-  Future<List<ScannedRideAttendee>> getRideAttendeesAsScanResults(
-    DateTime date,
-  ) {
-    return _dao.getRideAttendeesAsScanResults(date);
-  }
+  Stream<int> watchRidesCount() => _dao.watchRidesCount();
 }

--- a/lib/repository/settings_repository.dart
+++ b/lib/repository/settings_repository.dart
@@ -4,13 +4,9 @@ import 'package:weforza/model/settings.dart';
 class SettingsRepository {
   SettingsRepository(this._settingsDao);
 
-  final ISettingsDao _settingsDao;
+  final SettingsDao _settingsDao;
 
-  Future<Settings> loadApplicationSettings() {
-    return _settingsDao.readApplicationSettings();
-  }
+  Future<Settings> read() => _settingsDao.read();
 
-  Future<void> writeApplicationSettings(Settings settings) async {
-    await _settingsDao.writeApplicationSettings(settings);
-  }
+  Future<void> write(Settings settings) => _settingsDao.write(settings);
 }

--- a/lib/riverpod/database/database_dao_provider.dart
+++ b/lib/riverpod/database/database_dao_provider.dart
@@ -9,11 +9,11 @@ import 'package:weforza/database/settings_dao.dart';
 import 'package:weforza/riverpod/database/database_provider.dart';
 
 /// This provider provides the device dao.
-final deviceDaoProvider = Provider<IDeviceDao>((ref) {
+final deviceDaoProvider = Provider<DeviceDao>((ref) {
   final database = ref.read(databaseProvider);
   final databaseTables = ref.read(databaseTableProvider);
 
-  return DeviceDao(
+  return DeviceDaoImpl(
     database.getDatabase(),
     databaseTables.device,
     databaseTables.member,

--- a/lib/riverpod/database/database_dao_provider.dart
+++ b/lib/riverpod/database/database_dao_provider.dart
@@ -13,68 +13,45 @@ final deviceDaoProvider = Provider<DeviceDao>((ref) {
   final database = ref.read(databaseProvider);
   final databaseTables = ref.read(databaseTableProvider);
 
-  return DeviceDaoImpl(
-    database.getDatabase(),
-    databaseTables.device,
-    databaseTables.member,
-  );
+  return DeviceDaoImpl(database.getDatabase(), databaseTables);
 });
 
 /// This provider provides the export rides dao.
-final exportRidesDaoProvider = Provider<IExportRidesDao>((ref) {
+final exportRidesDaoProvider = Provider<ExportRidesDao>((ref) {
   final database = ref.read(databaseProvider);
   final databaseTables = ref.read(databaseTableProvider);
 
-  return ExportRidesDao(
-    database.getDatabase(),
-    databaseTables.member,
-    databaseTables.ride,
-    databaseTables.rideAttendee,
-  );
+  return ExportRidesDaoImpl(database.getDatabase(), databaseTables);
 });
 
 /// This provider provides the import members dao.
-final importMembersDaoProvider = Provider<IImportMembersDao>((ref) {
+final importMembersDaoProvider = Provider<ImportMembersDao>((ref) {
   final database = ref.read(databaseProvider);
   final databaseTables = ref.read(databaseTableProvider);
 
-  return ImportMembersDao(
-    database.getDatabase(),
-    databaseTables.member,
-    databaseTables.device,
-  );
+  return ImportMembersDaoImpl(database.getDatabase(), databaseTables);
 });
 
 /// This provider provides the member dao.
-final memberDaoProvider = Provider<IMemberDao>((ref) {
+final memberDaoProvider = Provider<MemberDao>((ref) {
   final database = ref.read(databaseProvider);
   final databaseTables = ref.read(databaseTableProvider);
 
-  return MemberDao(
-    database.getDatabase(),
-    databaseTables.member,
-    databaseTables.rideAttendee,
-    databaseTables.device,
-  );
+  return MemberDaoImpl(database.getDatabase(), databaseTables);
 });
 
 /// This provider provides the ride dao.
-final rideDaoProvider = Provider<IRideDao>((ref) {
+final rideDaoProvider = Provider<RideDao>((ref) {
   final database = ref.read(databaseProvider);
   final databaseTables = ref.read(databaseTableProvider);
 
-  return RideDao(
-    database.getDatabase(),
-    databaseTables.member,
-    databaseTables.ride,
-    databaseTables.rideAttendee,
-  );
+  return RideDaoImpl(database.getDatabase(), databaseTables);
 });
 
 /// This provider provides the application settings dao.
-final settingsDaoProvider = Provider<ISettingsDao>((ref) {
+final settingsDaoProvider = Provider<SettingsDao>((ref) {
   final database = ref.read(databaseProvider);
   final databaseTables = ref.read(databaseTableProvider);
 
-  return SettingsDao(database.getDatabase(), databaseTables.settings);
+  return SettingsDaoImpl(database.getDatabase(), databaseTables);
 });

--- a/lib/riverpod/file_handler_provider.dart
+++ b/lib/riverpod/file_handler_provider.dart
@@ -2,4 +2,4 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/file/file_handler.dart';
 
 /// This provider provides the file handler.
-final fileHandlerProvider = Provider<IFileHandler>((_) => FileHandler());
+final fileHandlerProvider = Provider<FileHandler>((_) => IoFileHandler());

--- a/lib/riverpod/member/export_members_provider.dart
+++ b/lib/riverpod/member/export_members_provider.dart
@@ -19,7 +19,7 @@ final exportMembersProvider = Provider((ref) {
 class ExportMembersProvider {
   ExportMembersProvider(this.fileHandler, this.memberRepository);
 
-  final IFileHandler fileHandler;
+  final FileHandler fileHandler;
 
   final ExportMembersRepository memberRepository;
 

--- a/lib/riverpod/member/import_members_provider.dart
+++ b/lib/riverpod/member/import_members_provider.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:uuid/uuid.dart';
 import 'package:weforza/exceptions/exceptions.dart';
 import 'package:weforza/file/csv_file_reader.dart';
 import 'package:weforza/file/file_handler.dart';
@@ -80,11 +79,9 @@ class ImportMembersNotifier {
         return;
       }
 
-      const uuidGenerator = Uuid();
-
       final repository = ref.read(importMembersRepositoryProvider);
 
-      await repository.saveMembersWithDevices(members, uuidGenerator.v4);
+      await repository.saveMembersWithDevices(members);
 
       ref.refresh(memberListProvider);
       onProgress(ImportMembersState.done);

--- a/lib/riverpod/ride/export_rides_provider.dart
+++ b/lib/riverpod/ride/export_rides_provider.dart
@@ -21,7 +21,7 @@ class ExportRidesProvider {
 
   final ExportRidesRepository exportRidesRepository;
 
-  final IFileHandler fileHandler;
+  final FileHandler fileHandler;
 
   /// Save the given [ExportableRide]s to the given file.
   /// The extension determines how the data is structured inside the file.

--- a/lib/riverpod/ride/ride_list_provider.dart
+++ b/lib/riverpod/ride/ride_list_provider.dart
@@ -14,11 +14,11 @@ final rideListProvider = FutureProvider<List<Ride>>((ref) {
 final rideListCountProvider = StreamProvider<int>((ref) async* {
   final repository = ref.read(rideRepositoryProvider);
 
-  final curentRideCount = await repository.getCurrentRideCount();
+  final curentRideCount = await repository.getRidesCount();
 
   final controller = BehaviorSubject.seeded(curentRideCount);
 
-  final subscription = repository.getRideCount().listen((event) {
+  final subscription = repository.watchRidesCount().listen((event) {
     if (controller.isClosed) {
       return;
     }

--- a/lib/widgets/pages/member_list/member_list_item.dart
+++ b/lib/widgets/pages/member_list/member_list_item.dart
@@ -45,7 +45,7 @@ class MemberListItemState extends ConsumerState<MemberListItem> {
       widget.member.profileImageFilePath,
     );
 
-    memberAttendingCount = memberRepository.getAttendingCountForAttendee(
+    memberAttendingCount = memberRepository.getAttendingCount(
       widget.member.uuid,
     );
   }

--- a/lib/widgets/pages/member_list/member_list_item.dart
+++ b/lib/widgets/pages/member_list/member_list_item.dart
@@ -38,7 +38,7 @@ class MemberListItemState extends ConsumerState<MemberListItem> {
   late final Future<File?> memberProfileImage;
 
   void getProfileImageAndAttendingCount(
-    IFileHandler fileHander,
+    FileHandler fileHander,
     MemberRepository memberRepository,
   ) {
     memberProfileImage = fileHander.loadProfileImageFromDisk(

--- a/lib/widgets/pages/settings/settings_page.dart
+++ b/lib/widgets/pages/settings/settings_page.dart
@@ -38,7 +38,7 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
 
       final repository = ref.read(settingsRepositoryProvider);
 
-      return repository.writeApplicationSettings(newSettings).then((_) {
+      return repository.write(newSettings).then((_) {
         if (mounted) {
           ref.read(settingsProvider.notifier).state = newSettings;
         }


### PR DESCRIPTION
This PR replaces uses of `HashMap` with the literal equivalent.
It also adds the following fixes:
- stop using `Future.wait()` where not needed
- cleaned up the database / DAO layer
- stop using interface names that start with a capital `I`
- optimize database layer with record ref
- stop using UTC for `lastUpdated` dates

Fixes: #169 Fixes: #168 
Part of #144
Part of #146 