### PR TITLE
Review use of static

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,5 +5,6 @@ include: package:flutter_lints/flutter.yaml
 linter:
   rules:
     directives_ordering: true
+    prefer_constructors_over_static_methods: true
     prefer_single_quotes: true
     use_super_parameters: true

--- a/lib/model/device.dart
+++ b/lib/model/device.dart
@@ -3,12 +3,25 @@ import 'package:weforza/model/device_type.dart';
 /// A device is a piece of hardware that is owned by a person.
 /// Each device has a [creationDate], a [name], an [ownerId] and a [type].
 class Device {
+  /// The default constructor.
   Device({
     required this.creationDate,
     required this.name,
     required this.ownerId,
     this.type = DeviceType.unknown,
   }) : assert(ownerId.isNotEmpty && name.isNotEmpty);
+
+  /// Create a device from the given [key] and [values].
+  factory Device.of(String key, Map<String, dynamic> values) {
+    assert(key.isNotEmpty);
+
+    return Device(
+      creationDate: DateTime.parse(key),
+      name: values['deviceName'] as String,
+      ownerId: values['owner'] as String,
+      type: DeviceType.fromTypeIndex(values['type'] as int),
+    );
+  }
 
   /// The creation date of this device.
   /// This creation date is not indicative of the actual creation date
@@ -32,18 +45,6 @@ class Device {
   /// Convert this object to a Map.
   Map<String, dynamic> toMap() {
     return {'deviceName': name, 'owner': ownerId, 'type': type.typeIndex};
-  }
-
-  /// Create a device from the given [key] and [values].
-  static Device of(String key, Map<String, dynamic> values) {
-    assert(key.isNotEmpty);
-
-    return Device(
-      creationDate: DateTime.parse(key),
-      name: values['deviceName'] as String,
-      ownerId: values['owner'] as String,
-      type: DeviceType.fromTypeIndex(values['type'] as int),
-    );
   }
 
   @override

--- a/lib/model/member.dart
+++ b/lib/model/member.dart
@@ -2,6 +2,7 @@ import 'package:weforza/extensions/date_extension.dart';
 
 /// This class represents a member.
 class Member implements Comparable<Member> {
+  /// The default constuctor.
   Member({
     required this.uuid,
     required this.firstname,
@@ -11,6 +12,21 @@ class Member implements Comparable<Member> {
     required this.profileImageFilePath,
     required this.lastUpdated,
   }) : assert(uuid.isNotEmpty && firstname.isNotEmpty && lastname.isNotEmpty);
+
+  /// Create a member from the given [uuid] and [values].
+  factory Member.of(String uuid, Map<String, Object?> values) {
+    assert(uuid.isNotEmpty);
+
+    return Member(
+      uuid: uuid,
+      firstname: values['firstname'] as String,
+      lastname: values['lastname'] as String,
+      alias: values['alias'] as String? ?? '',
+      isActiveMember: values['active'] as bool? ?? true,
+      profileImageFilePath: values['profile'] as String?,
+      lastUpdated: DateTime.parse(values['lastUpdated'] as String),
+    );
+  }
 
   /// Regex for a member's first or last name or alias.
   ///
@@ -58,20 +74,6 @@ class Member implements Comparable<Member> {
       'profile': profileImageFilePath,
       'lastUpdated': lastUpdated.toStringWithoutMilliseconds(),
     };
-  }
-
-  /// Create a member from a Map and a given uuid.
-  static Member of(String uuid, Map<String, Object?> values) {
-    assert(uuid.isNotEmpty);
-    return Member(
-      uuid: uuid,
-      firstname: values['firstname'] as String,
-      lastname: values['lastname'] as String,
-      alias: values['alias'] as String? ?? '',
-      isActiveMember: values['active'] as bool? ?? true,
-      profileImageFilePath: values['profile'] as String?,
-      lastUpdated: DateTime.parse(values['lastUpdated'] as String),
-    );
   }
 
   @override


### PR DESCRIPTION
This PR enables `prefer_constructors_over_static_methods` and fixes the violations.

Now there are no static methods that create objects.
The only uses of `static` are now either `static const` or `static final` (where static const is impossible, i.e. `RegExp`)   

Fixes: #143