### PR TITLE
Debounce search

### DIFF
--- a/lib/model/debounce_search_delegate.dart
+++ b/lib/model/debounce_search_delegate.dart
@@ -16,6 +16,9 @@ class DebounceSearchDelegate {
   /// The debounce time for the stream events.
   final Duration debounceTime;
 
+  /// Get the current query.
+  String get currentQuery => _controller.value;
+
   /// Add a new [value] to the search query stream.
   void onQueryChanged(String value) {
     if (_controller.isClosed || _controller.value == value) {

--- a/lib/model/debounce_search_delegate.dart
+++ b/lib/model/debounce_search_delegate.dart
@@ -1,0 +1,37 @@
+import 'package:rxdart/rxdart.dart';
+
+/// This class represents a delegate that manages
+/// a stream of search query changes.
+///
+/// This delegate applies a [debounceTime] to the incoming events.
+class DebounceSearchDelegate {
+  /// The default constructor.
+  DebounceSearchDelegate({
+    this.debounceTime = const Duration(milliseconds: 500),
+  });
+
+  /// The internal controller.
+  final _controller = BehaviorSubject.seeded('');
+
+  /// The debounce time for the stream events.
+  final Duration debounceTime;
+
+  /// Add a new [value] to the search query stream.
+  void onQueryChanged(String value) {
+    if (_controller.isClosed || _controller.value == value) {
+      return;
+    }
+
+    _controller.add(value);
+  }
+
+  /// Get the stream of search query changes.
+  Stream<String> get searchQuery {
+    return _controller.debounceTime(debounceTime);
+  }
+
+  /// Dispose of this delegate.
+  void dispose() {
+    _controller.close();
+  }
+}

--- a/lib/model/ride_attendee_scanning/manual_selection_filter_options.dart
+++ b/lib/model/ride_attendee_scanning/manual_selection_filter_options.dart
@@ -11,17 +11,6 @@ class ManualSelectionFilterOptions {
   /// Whether scanned results should be shown.
   final bool showScannedResults;
 
-  /// Create a copy of this object.
-  ManualSelectionFilterOptions copyWith({
-    String? query,
-    bool? showScannedResults,
-  }) {
-    return ManualSelectionFilterOptions(
-      query: query ?? this.query,
-      showScannedResults: showScannedResults ?? this.showScannedResults,
-    );
-  }
-
   @override
   int get hashCode => Object.hash(query, showScannedResults);
 

--- a/lib/widgets/pages/member_list/member_list_page.dart
+++ b/lib/widgets/pages/member_list/member_list_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:rxdart/rxdart.dart';
 import 'package:weforza/generated/l10n.dart';
+import 'package:weforza/model/debounce_search_delegate.dart';
 import 'package:weforza/model/member.dart';
 import 'package:weforza/widgets/pages/export_members_page.dart';
 import 'package:weforza/widgets/pages/import_members_page.dart';
@@ -22,12 +22,9 @@ class MemberListPage extends ConsumerStatefulWidget {
 }
 
 class MemberListPageState extends ConsumerState<MemberListPage> {
-  // This controller manages the query stream.
-  // The input field creates it's own TextEditingController,
-  // as it starts with an empty string.
-  final BehaviorSubject<String> _queryController = BehaviorSubject.seeded('');
-
   final _controller = TextEditingController();
+
+  final _searchController = DebounceSearchDelegate();
 
   void _onMemberSelected(BuildContext context) {
     // Clear the search query.
@@ -106,14 +103,14 @@ class MemberListPageState extends ConsumerState<MemberListPage> {
             child: MemberList(
               onMemberSelected: () => _onMemberSelected(context),
               filter: _filterOnSearchQuery,
-              searchQueryStream: _queryController,
+              searchQueryStream: _searchController.searchQuery,
               searchField: TextFormField(
                 controller: _controller,
                 textInputAction: TextInputAction.search,
                 keyboardType: TextInputType.text,
                 autocorrect: false,
                 autovalidateMode: AutovalidateMode.disabled,
-                onChanged: _queryController.add,
+                onChanged: _searchController.onQueryChanged,
                 decoration: InputDecoration(
                   suffixIcon: const Icon(Icons.search),
                   labelText: S.of(context).SearchRiders,
@@ -181,13 +178,13 @@ class MemberListPageState extends ConsumerState<MemberListPage> {
               child: MemberList(
                 onMemberSelected: () => _onMemberSelected(context),
                 filter: _filterOnSearchQuery,
-                searchQueryStream: _queryController,
+                searchQueryStream: _searchController.searchQuery,
                 searchField: Padding(
                   padding: const EdgeInsets.all(8),
                   child: CupertinoSearchTextField(
                     controller: _controller,
                     suffixIcon: const Icon(CupertinoIcons.search),
-                    onChanged: _queryController.add,
+                    onChanged: _searchController.onQueryChanged,
                     placeholder: S.of(context).SearchRiders,
                   ),
                 ),
@@ -209,7 +206,7 @@ class MemberListPageState extends ConsumerState<MemberListPage> {
 
   @override
   void dispose() {
-    _queryController.close();
+    _searchController.dispose();
     _controller.dispose();
     super.dispose();
   }

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_filter_delegate.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_filter_delegate.dart
@@ -11,6 +11,14 @@ class ManualSelectionFilterDelegate {
   /// The internal show scanned results controller.
   final _showScannedResultsController = BehaviorSubject.seeded(true);
 
+  /// Get the current filters.
+  ManualSelectionFilterOptions get currentFilters {
+    return ManualSelectionFilterOptions(
+      query: _searchQueryController.currentQuery,
+      showScannedResults: _showScannedResultsController.value,
+    );
+  }
+
   /// Get the stream of combined filter changes.
   Stream<ManualSelectionFilterOptions> get filters {
     // combineLatest2() only emits when both streams have emitted a value.
@@ -25,6 +33,9 @@ class ManualSelectionFilterDelegate {
       ),
     );
   }
+
+  /// Get the filter value for the show scanned results filter.
+  bool get showScannedResults => _showScannedResultsController.value;
 
   /// Get the stream of changes to [ManualSelectionFilterOptions.showScannedResults].
   Stream<bool> get showScannedResultsStream => _showScannedResultsController;

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_filter_delegate.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_filter_delegate.dart
@@ -1,0 +1,47 @@
+import 'package:rxdart/rxdart.dart';
+import 'package:weforza/model/debounce_search_delegate.dart';
+import 'package:weforza/model/ride_attendee_scanning/manual_selection_filter_options.dart';
+
+/// This class represents the delegate
+/// for the filters on the manual selection page.
+class ManualSelectionFilterDelegate {
+  /// The internal search query controller.
+  final _searchQueryController = DebounceSearchDelegate();
+
+  /// The internal show scanned results controller.
+  final _showScannedResultsController = BehaviorSubject.seeded(true);
+
+  /// Get the stream of combined filter changes.
+  Stream<ManualSelectionFilterOptions> get filters {
+    // combineLatest2() only emits when both streams have emitted a value.
+    // However, both streams are seeded with an initial value,
+    // so this is fine.
+    return Rx.combineLatest2<String, bool, ManualSelectionFilterOptions>(
+      _searchQueryController.searchQuery,
+      _showScannedResultsController,
+      (query, showScannedResults) => ManualSelectionFilterOptions(
+        query: query,
+        showScannedResults: showScannedResults,
+      ),
+    );
+  }
+
+  /// Get the stream of changes to [ManualSelectionFilterOptions.showScannedResults].
+  Stream<bool> get showScannedResultsStream => _showScannedResultsController;
+
+  /// Change the value for the search query filter.
+  void onSearchQueryChanged(String value) {
+    _searchQueryController.onQueryChanged(value);
+  }
+
+  /// Change the value for the show scanned results filter.
+  void onShowScannedResultsChanged(bool value) {
+    _showScannedResultsController.add(value);
+  }
+
+  /// Dispose of this delegate.
+  void dispose() {
+    _searchQueryController.dispose();
+    _showScannedResultsController.close();
+  }
+}

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:rxdart/rxdart.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/model/member.dart';
 import 'package:weforza/model/ride_attendee_scanning/manual_selection_filter_options.dart';
@@ -8,6 +7,7 @@ import 'package:weforza/model/ride_attendee_scanning/ride_attendee_scanning_dele
 import 'package:weforza/widgets/common/rider_search_filter_empty.dart';
 import 'package:weforza/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart';
 import 'package:weforza/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_button_bar.dart';
+import 'package:weforza/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_filter_delegate.dart';
 import 'package:weforza/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_empty.dart';
 import 'package:weforza/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_item.dart';
 import 'package:weforza/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_save_button.dart';
@@ -31,9 +31,7 @@ class ManualSelectionList extends StatefulWidget {
 class _ManualSelectionListState extends State<ManualSelectionList> {
   Future<List<Member>>? _activeMembersFuture;
 
-  final _filtersController = BehaviorSubject.seeded(
-    const ManualSelectionFilterOptions(),
-  );
+  final _filtersController = ManualSelectionFilterDelegate();
 
   Future<void>? _saveAttendeesFuture;
 
@@ -85,16 +83,6 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
     );
   }
 
-  void _onSearchQueryChanged(String newQuery) {
-    _filtersController.add(_filtersController.value.copyWith(query: newQuery));
-  }
-
-  void _onShowScannedResultsChanged(bool newValue) {
-    _filtersController.add(
-      _filtersController.value.copyWith(showScannedResults: newValue),
-    );
-  }
-
   /// Sort the active members on their name and alias.
   Future<List<Member>> _sortActiveMembers() {
     final items = widget.delegate.activeMembers;
@@ -124,7 +112,7 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
             keyboardType: TextInputType.text,
             autocorrect: false,
             autovalidateMode: AutovalidateMode.disabled,
-            onChanged: _onSearchQueryChanged,
+            onChanged: _filtersController.onSearchQueryChanged,
             decoration: InputDecoration(
               suffixIcon: const Icon(Icons.search),
               labelText: translator.SearchRiders,
@@ -137,15 +125,14 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
             padding: const EdgeInsets.all(8),
             child: CupertinoSearchTextField(
               suffixIcon: const Icon(CupertinoIcons.search),
-              onChanged: _onSearchQueryChanged,
+              onChanged: _filtersController.onSearchQueryChanged,
               placeholder: translator.SearchRiders,
             ),
           ),
         ),
         Expanded(
           child: StreamBuilder<ManualSelectionFilterOptions>(
-            initialData: _filtersController.value,
-            stream: _filtersController,
+            stream: _filtersController.filters,
             builder: (context, snapshot) {
               final results = _filterActiveMembers(items, snapshot.data!);
 
@@ -170,9 +157,8 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
             onPressed: () => _onSaveRideAttendeesButtonPressed(context),
           ),
           showScannedResultsToggle: ShowScannedResultsToggle(
-            initialValue: _filtersController.value.showScannedResults,
-            onChanged: _onShowScannedResultsChanged,
-            stream: _filtersController.map((f) => f.showScannedResults),
+            onChanged: _filtersController.onShowScannedResultsChanged,
+            stream: _filtersController.showScannedResultsStream,
           ),
         ),
       ],
@@ -203,7 +189,7 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
 
   @override
   void dispose() {
-    _filtersController.close();
+    _filtersController.dispose();
     super.dispose();
   }
 }

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list.dart
@@ -132,6 +132,7 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
         ),
         Expanded(
           child: StreamBuilder<ManualSelectionFilterOptions>(
+            initialData: _filtersController.currentFilters,
             stream: _filtersController.filters,
             builder: (context, snapshot) {
               final results = _filterActiveMembers(items, snapshot.data!);
@@ -157,6 +158,7 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
             onPressed: () => _onSaveRideAttendeesButtonPressed(context),
           ),
           showScannedResultsToggle: ShowScannedResultsToggle(
+            initialValue: _filtersController.showScannedResults,
             onChanged: _filtersController.onShowScannedResultsChanged,
             stream: _filtersController.showScannedResultsStream,
           ),

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/show_scanned_results_toggle.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/show_scanned_results_toggle.dart
@@ -8,13 +8,13 @@ import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 class ShowScannedResultsToggle extends StatelessWidget {
   const ShowScannedResultsToggle({
     super.key,
-    this.initialValue,
+    required this.initialValue,
     required this.onChanged,
     required this.stream,
   });
 
   /// The initial value for the toggle switch.
-  final bool? initialValue;
+  final bool initialValue;
 
   /// The handler for changes to the toggle value.
   final void Function(bool) onChanged;

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/show_scanned_results_toggle.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/show_scanned_results_toggle.dart
@@ -8,13 +8,13 @@ import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 class ShowScannedResultsToggle extends StatelessWidget {
   const ShowScannedResultsToggle({
     super.key,
-    required this.initialValue,
+    this.initialValue,
     required this.onChanged,
     required this.stream,
   });
 
   /// The initial value for the toggle switch.
-  final bool initialValue;
+  final bool? initialValue;
 
   /// The handler for changes to the toggle value.
   final void Function(bool) onChanged;


### PR DESCRIPTION
This PR adds debounced search to the member list and manual selection list pages.

It also optimizes the rebuilds for the `show scanned` toggle.

Fixes: #155 