### PR TITLE
Add android.hardware.bluetooth_le capability

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="be.weforza.app">
+    <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
          In most cases you can leave this as-is, but you if you want to provide


### PR DESCRIPTION
This PR adds the Bluetooth Low Energy capability to the Android Manifest.
It turns out iOS does not have an equivalent.

Fixes: #148 