### PR TITLE
App theme refactor

### DIFF
--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -23,9 +23,6 @@ abstract class ApplicationTheme {
 
   static const Color importMembersDoneIconColor = Colors.green;
 
-  // TODO: remove an use primary color
-  static const Color rideListItemEvenMonthColor = Colors.blue;
-
   /// The text style for android form errors.
   static const androidFormErrorStyle = TextStyle(
     fontSize: 16,

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -12,11 +12,6 @@ abstract class ApplicationTheme {
 
   // ==== Miscellaneous stuff
 
-  /// This color is used for Icons in lists that show some information
-  /// when there is nothing to show.
-  static const Color listInformationalIconColor =
-      primaryColor; // TODO: remove and use primary color
-
   static const Color deleteItemButtonTextColor = Colors.red;
 
   static const importWarningTextStyle = TextStyle(color: Colors.red);

--- a/lib/widgets/common/generic_error.dart
+++ b/lib/widgets/common/generic_error.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:weforza/theme/app_theme.dart';
-import 'package:weforza/widgets/platform/platform_aware_widget.dart';
+import 'package:weforza/widgets/platform/platform_aware_icon.dart';
 
 /// This class represents a generic error widget.
 ///
@@ -9,36 +8,16 @@ import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 class GenericError extends StatelessWidget {
   GenericError({
     super.key,
+    this.androidIcon,
+    this.iosIcon,
     required this.text,
-    this.iconBuilder,
-  })  : assert(text.isNotEmpty);
+  }) : assert(text.isNotEmpty);
+
+  final IconData? androidIcon;
+
+  final IconData? iosIcon;
 
   final String text;
-  final Widget Function(BuildContext context)? iconBuilder;
-
-  /// Build a Widget that serves as the icon.
-  /// Returns the result of [iconBuilder]
-  /// or a default warning icon.
-  Widget _buildIcon(BuildContext context) {
-    final builder = iconBuilder;
-
-    if (builder != null) {
-      return builder(context);
-    }
-
-    return PlatformAwareWidget(
-      android: () => Icon(
-        Icons.warning,
-        color: ApplicationTheme.listInformationalIconColor,
-        size: MediaQuery.of(context).size.shortestSide * .1,
-      ),
-      ios: () => Icon(
-        CupertinoIcons.exclamationmark_triangle_fill,
-        color: ApplicationTheme.listInformationalIconColor,
-        size: MediaQuery.of(context).size.shortestSide * .1,
-      ),
-    );
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -46,7 +25,11 @@ class GenericError extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
-          _buildIcon(context),
+          PlatformAwareIcon(
+            androidIcon: androidIcon ?? Icons.warning,
+            iosIcon: iosIcon ?? CupertinoIcons.exclamationmark_triangle_fill,
+            size: MediaQuery.of(context).size.shortestSide * .1,
+          ),
           Padding(
             padding: const EdgeInsets.only(top: 4),
             child: Text(text),

--- a/lib/widgets/common/rider_search_filter_empty.dart
+++ b/lib/widgets/common/rider_search_filter_empty.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/cupertino.dart' show CupertinoIcons;
 import 'package:flutter/material.dart';
 import 'package:weforza/generated/l10n.dart';
-import 'package:weforza/theme/app_theme.dart';
-import 'package:weforza/widgets/platform/platform_aware_widget.dart';
+import 'package:weforza/widgets/platform/platform_aware_icon.dart';
 
 class RiderSearchFilterEmpty extends StatelessWidget {
   const RiderSearchFilterEmpty({super.key});
@@ -12,17 +11,10 @@ class RiderSearchFilterEmpty extends StatelessWidget {
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
-        PlatformAwareWidget(
-          android: () => Icon(
-            Icons.people,
-            color: ApplicationTheme.listInformationalIconColor,
-            size: MediaQuery.of(context).size.shortestSide * .1,
-          ),
-          ios: () => Icon(
-            CupertinoIcons.person_2_fill,
-            color: ApplicationTheme.listInformationalIconColor,
-            size: MediaQuery.of(context).size.shortestSide * .1,
-          ),
+        PlatformAwareIcon(
+          androidIcon: Icons.people,
+          iosIcon: CupertinoIcons.person_2_fill,
+          size: MediaQuery.of(context).size.shortestSide * .1,
         ),
         Padding(
           padding: const EdgeInsets.only(top: 4, left: 16, right: 16),

--- a/lib/widgets/pages/import_members_page.dart
+++ b/lib/widgets/pages/import_members_page.dart
@@ -121,21 +121,9 @@ class ImportMembersPageState extends ConsumerState<ImportMembersPage> {
 
         if (error is JsonFormatIncompatibleException) {
           return GenericError(
+            androidIcon: Icons.insert_drive_file,
+            iosIcon: CupertinoIcons.doc_fill,
             text: translator.ImportMembersIncompatibleFileJsonContents,
-            iconBuilder: (context) {
-              return PlatformAwareWidget(
-                android: () => Icon(
-                  Icons.insert_drive_file,
-                  color: ApplicationTheme.listInformationalIconColor,
-                  size: MediaQuery.of(context).size.shortestSide * .1,
-                ),
-                ios: () => Icon(
-                  CupertinoIcons.doc_fill,
-                  color: ApplicationTheme.listInformationalIconColor,
-                  size: MediaQuery.of(context).size.shortestSide * .1,
-                ),
-              );
-            },
           );
         }
 

--- a/lib/widgets/pages/member_details/member_devices_list/member_devices_list_empty.dart
+++ b/lib/widgets/pages/member_details/member_devices_list/member_devices_list_empty.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/riverpod/member/selected_member_provider.dart';
-import 'package:weforza/theme/app_theme.dart';
 import 'package:weforza/widgets/pages/device_form.dart';
+import 'package:weforza/widgets/platform/platform_aware_icon.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 
 /// This widget represents the empty member devices list.
@@ -24,22 +24,13 @@ class MemberDevicesListEmpty extends StatelessWidget {
     return Center(
       child: LayoutBuilder(
         builder: (context, constraints) {
-          final size = constraints.biggest;
-
           return Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
-              PlatformAwareWidget(
-                android: () => Icon(
-                  Icons.devices_other,
-                  color: ApplicationTheme.listInformationalIconColor,
-                  size: size.shortestSide * .1,
-                ),
-                ios: () => Icon(
-                  Icons.devices_other,
-                  color: ApplicationTheme.listInformationalIconColor,
-                  size: size.shortestSide * .1,
-                ),
+              PlatformAwareIcon(
+                androidIcon: Icons.devices_other,
+                iosIcon: Icons.devices_other,
+                size: constraints.biggest.shortestSide * .1,
               ),
               Padding(
                 padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),

--- a/lib/widgets/pages/member_list/member_list_empty.dart
+++ b/lib/widgets/pages/member_list/member_list_empty.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:weforza/generated/l10n.dart';
-import 'package:weforza/theme/app_theme.dart';
-import 'package:weforza/widgets/platform/platform_aware_widget.dart';
+import 'package:weforza/widgets/platform/platform_aware_icon.dart';
 
 class MemberListEmpty extends StatelessWidget {
   const MemberListEmpty({super.key});
@@ -12,17 +11,10 @@ class MemberListEmpty extends StatelessWidget {
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
-        PlatformAwareWidget(
-          android: () => Icon(
-            Icons.people,
-            color: ApplicationTheme.listInformationalIconColor,
-            size: MediaQuery.of(context).size.shortestSide * .1,
-          ),
-          ios: () => Icon(
-            CupertinoIcons.person_2_fill,
-            color: ApplicationTheme.listInformationalIconColor,
-            size: MediaQuery.of(context).size.shortestSide * .1,
-          ),
+        PlatformAwareIcon(
+          androidIcon: Icons.people,
+          iosIcon: CupertinoIcons.person_2_fill,
+          size: MediaQuery.of(context).size.shortestSide * .1,
         ),
         Padding(
           padding: const EdgeInsets.only(top: 4, left: 16, right: 16),

--- a/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
@@ -3,6 +3,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/theme/app_theme.dart';
+import 'package:weforza/widgets/platform/platform_aware_icon.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 
 /// This widget represents the base for a generic scan error.
@@ -10,17 +11,21 @@ import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 /// and a secondary action button.
 class _GenericScanErrorBase extends StatelessWidget {
   const _GenericScanErrorBase({
+    required this.androidIcon,
     required this.errorMessage,
-    required this.iconBuilder,
+    required this.iosIcon,
     required this.primaryButton,
     this.secondaryButton,
   });
 
+  /// The icon for Android.
+  final IconData androidIcon;
+
   /// The error message to display.
   final String errorMessage;
 
-  /// The builder for the icon.
-  final Widget Function(double size) iconBuilder;
+  /// The icon for iOS.
+  final IconData iosIcon;
 
   /// The primary button that is displayed under the [errorMessage].
   final Widget primaryButton;
@@ -30,12 +35,14 @@ class _GenericScanErrorBase extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final iconSize = MediaQuery.of(context).size.shortestSide * .1;
-
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        iconBuilder(iconSize),
+        PlatformAwareIcon(
+          androidIcon: androidIcon,
+          iosIcon: iosIcon,
+          size: MediaQuery.of(context).size.shortestSide * .1,
+        ),
         Flexible(
           child: Padding(
             padding: const EdgeInsets.fromLTRB(8, 8, 8, 20),
@@ -73,12 +80,9 @@ class BluetoothDisabledError extends StatelessWidget {
     final translator = S.of(context);
 
     return _GenericScanErrorBase(
+      androidIcon: Icons.bluetooth_disabled,
       errorMessage: translator.ScanAbortedBluetoothDisabled,
-      iconBuilder: (iconSize) => Icon(
-        Icons.bluetooth_disabled,
-        color: ApplicationTheme.listInformationalIconColor,
-        size: iconSize,
-      ),
+      iosIcon: Icons.bluetooth_disabled,
       primaryButton: PlatformAwareWidget(
         android: () => ElevatedButton(
           onPressed: () => AppSettings.openBluetoothSettings(),
@@ -118,19 +122,9 @@ class GenericScanError extends StatelessWidget {
     final translator = S.of(context);
 
     return _GenericScanErrorBase(
+      androidIcon: Icons.warning,
       errorMessage: translator.GenericError,
-      iconBuilder: (iconSize) => PlatformAwareWidget(
-        android: () => Icon(
-          Icons.warning,
-          color: ApplicationTheme.listInformationalIconColor,
-          size: iconSize,
-        ),
-        ios: () => Icon(
-          CupertinoIcons.exclamationmark_triangle_fill,
-          color: ApplicationTheme.listInformationalIconColor,
-          size: iconSize,
-        ),
-      ),
+      iosIcon: CupertinoIcons.exclamationmark_triangle_fill,
       primaryButton: PlatformAwareWidget(
         android: () => ElevatedButton(
           child: Text(translator.GoBackToDetailPage),
@@ -159,19 +153,9 @@ class PermissionDeniedError extends StatelessWidget {
     final translator = S.of(context);
 
     return _GenericScanErrorBase(
+      androidIcon: Icons.warning,
       errorMessage: translator.ScanAbortedPermissionDenied,
-      iconBuilder: (iconSize) => PlatformAwareWidget(
-        android: () => Icon(
-          Icons.warning,
-          color: ApplicationTheme.listInformationalIconColor,
-          size: iconSize,
-        ),
-        ios: () => Icon(
-          CupertinoIcons.exclamationmark_triangle_fill,
-          color: ApplicationTheme.listInformationalIconColor,
-          size: iconSize,
-        ),
-      ),
+      iosIcon: CupertinoIcons.exclamationmark_triangle_fill,
       primaryButton: PlatformAwareWidget(
         android: () => ElevatedButton(
           child: Text(translator.GoToSettings),

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_empty.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_empty.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:weforza/generated/l10n.dart';
-import 'package:weforza/theme/app_theme.dart';
+import 'package:weforza/widgets/platform/platform_aware_icon.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 
 /// This widget represents the empty manual selection list.
@@ -15,17 +15,10 @@ class ManualSelectionListEmpty extends StatelessWidget {
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
-        PlatformAwareWidget(
-          android: () => Icon(
-            Icons.people,
-            color: ApplicationTheme.listInformationalIconColor,
-            size: MediaQuery.of(context).size.shortestSide * .1,
-          ),
-          ios: () => Icon(
-            CupertinoIcons.person_2_fill,
-            color: ApplicationTheme.listInformationalIconColor,
-            size: MediaQuery.of(context).size.shortestSide * .1,
-          ),
+        PlatformAwareIcon(
+          androidIcon: Icons.people,
+          iosIcon: CupertinoIcons.person_2_fill,
+          size: MediaQuery.of(context).size.shortestSide * .1,
         ),
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 4, 16, 20),

--- a/lib/widgets/pages/ride_details/ride_details_attendees/ride_details_attendees_list_empty.dart
+++ b/lib/widgets/pages/ride_details/ride_details_attendees/ride_details_attendees_list_empty.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:weforza/generated/l10n.dart';
-import 'package:weforza/theme/app_theme.dart';
-import 'package:weforza/widgets/platform/platform_aware_widget.dart';
+import 'package:weforza/widgets/platform/platform_aware_icon.dart';
 
 class RideDetailsAttendeesListEmpty extends StatelessWidget {
   const RideDetailsAttendeesListEmpty({super.key});
@@ -13,17 +12,10 @@ class RideDetailsAttendeesListEmpty extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
-          PlatformAwareWidget(
-            android: () => Icon(
-              Icons.people,
-              color: ApplicationTheme.listInformationalIconColor,
-              size: MediaQuery.of(context).size.shortestSide * .1,
-            ),
-            ios: () => Icon(
-              CupertinoIcons.person_2_fill,
-              color: ApplicationTheme.listInformationalIconColor,
-              size: MediaQuery.of(context).size.shortestSide * .1,
-            ),
+          PlatformAwareIcon(
+            androidIcon: Icons.people,
+            iosIcon: CupertinoIcons.person_2_fill,
+            size: MediaQuery.of(context).size.shortestSide * .1,
           ),
           Padding(
             padding: const EdgeInsets.only(top: 4),

--- a/lib/widgets/pages/ride_list/ride_list_empty.dart
+++ b/lib/widgets/pages/ride_list/ride_list_empty.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:weforza/generated/l10n.dart';
-import 'package:weforza/theme/app_theme.dart';
+import 'package:weforza/widgets/platform/platform_aware_icon.dart';
 
 class RideListEmpty extends StatelessWidget {
   const RideListEmpty({super.key});
@@ -11,9 +11,9 @@ class RideListEmpty extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
-          Icon(
-            Icons.directions_bike,
-            color: ApplicationTheme.listInformationalIconColor,
+          PlatformAwareIcon(
+            androidIcon: Icons.directions_bike,
+            iosIcon: Icons.directions_bike,
             size: MediaQuery.of(context).size.shortestSide * .1,
           ),
           Padding(

--- a/lib/widgets/pages/ride_list/ride_list_item.dart
+++ b/lib/widgets/pages/ride_list/ride_list_item.dart
@@ -1,8 +1,8 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/model/ride.dart';
 import 'package:weforza/riverpod/ride/selected_ride_provider.dart';
-import 'package:weforza/theme/app_theme.dart';
 import 'package:weforza/widgets/common/ride_list_item_attendee_counter.dart';
 import 'package:weforza/widgets/pages/ride_details/ride_details_page.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
@@ -13,29 +13,38 @@ class RideListItem extends ConsumerWidget {
 
   final Ride ride;
 
-  TextStyle get itemTextStyle {
+  Color? _getMonthColor(BuildContext context) {
     if (ride.date.month % 2 == 0) {
-      return const TextStyle(
-        color: ApplicationTheme.rideListItemEvenMonthColor,
-      );
+      switch (Theme.of(context).platform) {
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.linux:
+        case TargetPlatform.windows:
+          return Colors.blue;
+        case TargetPlatform.iOS:
+        case TargetPlatform.macOS:
+          return CupertinoColors.activeBlue;
+      }
     }
 
-    return const TextStyle();
+    return null;
   }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final style = TextStyle(color: _getMonthColor(context));
+
     final content = Row(
       children: <Widget>[
         Expanded(
           child: Text(
             ride.getFormattedDate(context, false),
-            style: itemTextStyle,
+            style: style,
           ),
         ),
         RideListItemAttendeeCounter(
           key: ValueKey(ride.date),
-          counterStyle: itemTextStyle,
+          counterStyle: style,
           rideDate: ride.date,
         ),
       ],

--- a/lib/widgets/platform/platform_aware_icon.dart
+++ b/lib/widgets/platform/platform_aware_icon.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:weforza/widgets/platform/platform_aware_widget.dart';
+
+/// This widget represents an [Icon] that adapts itself to the current platform.
+class PlatformAwareIcon extends StatelessWidget {
+  const PlatformAwareIcon({
+    super.key,
+    this.androidColor = Colors.blue,
+    required this.androidIcon,
+    this.iosColor = CupertinoColors.activeBlue,
+    required this.iosIcon,
+    this.size,
+  });
+
+  /// The color for the [androidIcon].
+  ///
+  /// Defaults to [Colors.blue].
+  final Color androidColor;
+
+  /// The icon for Android.
+  final IconData androidIcon;
+
+  /// The color for the [iosIcon].
+  final Color iosColor;
+
+  /// The icon for iOS.
+  ///
+  /// Defaults to [CupertinoColors.activeBlue].
+  final IconData iosIcon;
+
+  /// The size for the icon.
+  final double? size;
+
+  @override
+  Widget build(BuildContext context) {
+    return PlatformAwareWidget(
+      android: () => Icon(androidIcon, color: androidColor, size: size),
+      ios: () => Icon(iosIcon, color: iosColor, size: size),
+    );
+  }
+}


### PR DESCRIPTION
This PR cleans up usages of platform aware `Icon()` widgets. It also fixes the color of even months to use `CupertinoColors.activeBlue` on iOS.

Part of #145 