### PR TITLE
Remove secondary color; refactor AnimatedCheckmark 

### DIFF
--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -8,14 +8,9 @@ abstract class ApplicationTheme {
   /// The primary color is defined as a [MaterialColor].
   static const MaterialColor primaryColor = Colors.blue;
 
-  static const Color secondaryColor = Color(0xFF64B5F6);
-
-  // ==== Miscellaneous stuff
-
   /// The Android theme.
   static ThemeData androidTheme() {
     return ThemeData(
-      splashColor: secondaryColor.withAlpha(150),
       appBarTheme: const AppBarTheme(
         systemOverlayStyle: SystemUiOverlayStyle.light,
       ),
@@ -40,17 +35,13 @@ abstract class ApplicationTheme {
           ),
         ),
       ),
-      colorScheme: ColorScheme.fromSwatch(
-        primarySwatch: primaryColor,
-      ).copyWith(secondary: secondaryColor),
+      colorScheme: ColorScheme.fromSwatch(primarySwatch: primaryColor),
     );
   }
 
   /// The iOS theme.
   static CupertinoThemeData iosTheme() {
-    return const CupertinoThemeData(
-      primaryColor: primaryColor,
-      primaryContrastingColor: secondaryColor,
-    );
+    // TODO: use active blue
+    return const CupertinoThemeData(primaryColor: primaryColor);
   }
 }

--- a/lib/widgets/custom/animated_checkmark.dart
+++ b/lib/widgets/custom/animated_checkmark.dart
@@ -1,29 +1,52 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:weforza/widgets/custom/animated_path_painter.dart';
 
+/// This widget represents a checkmark that animates its path being painted.
 class AnimatedCheckmark extends StatefulWidget {
   const AnimatedCheckmark({
     super.key,
-    this.duration = const Duration(milliseconds: 300),
-    required this.color,
-    this.strokeWidth = 4.0,
+    this.color,
+    this.duration = const Duration(milliseconds: 500),
+    required this.size,
     this.strokeCap = StrokeCap.round,
     this.strokeJoin = StrokeJoin.round,
-    required this.size,
-  })  : assert(strokeWidth > 0.0);
+    this.strokeWidth = 4.0,
+  }) : assert(strokeWidth > 0.0);
 
+  /// The color for the stroke.
+  ///
+  /// If this is null, the Theme's primary color is used.
+  final Color? color;
+
+  /// The duration of the animation.
+  ///
+  /// Defaults to 500 milliseconds.
   final Duration duration;
-  final Color color;
-  final StrokeCap strokeCap;
-  final double strokeWidth;
-  final StrokeJoin strokeJoin;
+
+  /// The size of the checkmark.
   final Size size;
 
+  /// The stroke cap for the painter.
+  ///
+  /// Defaults to [StrokeCap.round].
+  final StrokeCap strokeCap;
+
+  /// The width of the painter's stroke.
+  ///
+  /// Defaults to 4.
+  final double strokeWidth;
+
+  /// The stroke join of the painter.
+  ///
+  /// Defaults to [StrokeJoin.round].
+  final StrokeJoin strokeJoin;
+
   @override
-  AnimatedCheckmarkState createState() => AnimatedCheckmarkState();
+  State<AnimatedCheckmark> createState() => _AnimatedCheckmarkState();
 }
 
-class AnimatedCheckmarkState extends State<AnimatedCheckmark>
+class _AnimatedCheckmarkState extends State<AnimatedCheckmark>
     with SingleTickerProviderStateMixin {
   late AnimationController _controller;
   late Animation<double> _animation;
@@ -36,27 +59,6 @@ class AnimatedCheckmarkState extends State<AnimatedCheckmark>
     _controller.forward();
   }
 
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return CustomPaint(
-      size: widget.size,
-      painter: AnimatedPathPainter(
-        animation: _animation,
-        color: widget.color,
-        strokeJoin: widget.strokeJoin,
-        strokeWidth: widget.strokeWidth,
-        strokeCap: widget.strokeCap,
-        createPath: _createPath,
-      ),
-    );
-  }
-
   Path _createPath(Size size) {
     final xOffset = size.width * .1;
     final yOffset = -(size.height * .1);
@@ -65,5 +67,49 @@ class AnimatedCheckmarkState extends State<AnimatedCheckmark>
       ..moveTo((size.width * .8) + xOffset, (size.height * .2) + yOffset)
       ..lineTo((size.width * .3) + xOffset, size.height + yOffset)
       ..lineTo(xOffset, (size.height * .8) + yOffset);
+  }
+
+  Color _resolveColor(BuildContext context) {
+    Color? effectiveColor = widget.color;
+
+    final theme = Theme.of(context);
+
+    if (effectiveColor == null) {
+      switch (theme.platform) {
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.linux:
+        case TargetPlatform.windows:
+          effectiveColor = theme.primaryColor;
+          break;
+        case TargetPlatform.iOS:
+        case TargetPlatform.macOS:
+          effectiveColor = CupertinoTheme.of(context).primaryColor;
+          break;
+      }
+    }
+
+    return effectiveColor;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      size: widget.size,
+      painter: AnimatedPathPainter(
+        animation: _animation,
+        color: _resolveColor(context),
+        strokeJoin: widget.strokeJoin,
+        strokeWidth: widget.strokeWidth,
+        strokeCap: widget.strokeCap,
+        createPath: _createPath,
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
   }
 }

--- a/lib/widgets/custom/animated_checkmark.dart
+++ b/lib/widgets/custom/animated_checkmark.dart
@@ -113,3 +113,68 @@ class _AnimatedCheckmarkState extends State<AnimatedCheckmark>
     super.dispose();
   }
 }
+
+/// This widget represents an [AnimatedCheckmark]
+/// that scales itself to a [fraction] of the available layout.
+class AdaptiveAnimatedCheckmark extends StatelessWidget {
+  const AdaptiveAnimatedCheckmark({
+    super.key,
+    this.color,
+    this.duration = const Duration(milliseconds: 500),
+    this.fraction = 0.3,
+    this.strokeCap = StrokeCap.round,
+    this.strokeJoin = StrokeJoin.round,
+    this.strokeWidth = 4.0,
+  });
+
+  /// The color for the stroke.
+  ///
+  /// If this is null, the Theme's primary color is used.
+  final Color? color;
+
+  /// The duration of the animation.
+  ///
+  /// Defaults to 500 milliseconds.
+  final Duration duration;
+
+  /// The percent of the shortest available constraint that this
+  /// animated checkmark should occupy.
+  ///
+  /// Defaults to 30 percent.
+  final double fraction;
+
+  /// The stroke cap for the painter.
+  ///
+  /// Defaults to [StrokeCap.round].
+  final StrokeCap strokeCap;
+
+  /// The width of the painter's stroke.
+  ///
+  /// Defaults to 4.
+  final double strokeWidth;
+
+  /// The stroke join of the painter.
+  ///
+  /// Defaults to [StrokeJoin.round].
+  final StrokeJoin strokeJoin;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final paintSize = constraints.biggest.shortestSide * fraction;
+
+          return AnimatedCheckmark(
+            color: color,
+            duration: duration,
+            size: Size.square(paintSize),
+            strokeCap: strokeCap,
+            strokeJoin: strokeJoin,
+            strokeWidth: strokeWidth,
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/widgets/pages/export_members_page.dart
+++ b/lib/widgets/pages/export_members_page.dart
@@ -6,7 +6,6 @@ import 'package:weforza/exceptions/exceptions.dart';
 import 'package:weforza/file/file_handler.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/riverpod/member/export_members_provider.dart';
-import 'package:weforza/theme/app_theme.dart';
 import 'package:weforza/widgets/common/file_extension_selection.dart';
 import 'package:weforza/widgets/common/filename_input_field.dart';
 import 'package:weforza/widgets/common/generic_error.dart';
@@ -115,22 +114,7 @@ class ExportMembersPageState extends ConsumerState<ExportMembersPage> {
               return GenericError(text: translator.GenericError);
             }
 
-            return LayoutBuilder(
-              builder: (context, constraints) {
-                final paintSize = constraints.biggest.shortestSide * .3;
-                return Center(
-                  child: SizedBox.square(
-                    dimension: paintSize,
-                    child: Center(
-                      child: AnimatedCheckmark(
-                        color: ApplicationTheme.secondaryColor,
-                        size: Size.square(paintSize),
-                      ),
-                    ),
-                  ),
-                );
-              },
-            );
+            return const AdaptiveAnimatedCheckmark();
         }
       },
     );

--- a/lib/widgets/pages/export_ride_page.dart
+++ b/lib/widgets/pages/export_ride_page.dart
@@ -7,7 +7,6 @@ import 'package:weforza/file/file_handler.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/model/ride.dart';
 import 'package:weforza/riverpod/ride/export_rides_provider.dart';
-import 'package:weforza/theme/app_theme.dart';
 import 'package:weforza/widgets/common/file_extension_selection.dart';
 import 'package:weforza/widgets/common/filename_input_field.dart';
 import 'package:weforza/widgets/common/generic_error.dart';
@@ -129,18 +128,7 @@ class ExportRidePageState extends ConsumerState<ExportRidePage> {
               return GenericError(text: translator.GenericError);
             }
 
-            return LayoutBuilder(
-              builder: (context, constraints) {
-                final paintSize = constraints.biggest.shortestSide * .3;
-
-                return Center(
-                  child: AnimatedCheckmark(
-                    color: ApplicationTheme.secondaryColor,
-                    size: Size.square(paintSize),
-                  ),
-                );
-              },
-            );
+            return const AdaptiveAnimatedCheckmark();
         }
       },
     );

--- a/lib/widgets/pages/import_members_page.dart
+++ b/lib/widgets/pages/import_members_page.dart
@@ -6,7 +6,6 @@ import 'package:weforza/exceptions/exceptions.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/model/import_members_state.dart';
 import 'package:weforza/riverpod/member/import_members_provider.dart';
-import 'package:weforza/theme/app_theme.dart';
 import 'package:weforza/widgets/common/generic_error.dart';
 import 'package:weforza/widgets/custom/animated_checkmark.dart';
 import 'package:weforza/widgets/platform/platform_aware_loading_indicator.dart';
@@ -167,24 +166,7 @@ class ImportMembersPageState extends ConsumerState<ImportMembersPage> {
               ],
             );
           case ImportMembersState.done:
-            return Center(
-              child: LayoutBuilder(
-                builder: (context, constraints) {
-                  final paintSize = constraints.biggest.shortestSide * .3;
-                  return Center(
-                    child: SizedBox.square(
-                      dimension: paintSize,
-                      child: Center(
-                        child: AnimatedCheckmark(
-                          color: ApplicationTheme.secondaryColor,
-                          size: Size.square(paintSize),
-                        ),
-                      ),
-                    ),
-                  );
-                },
-              ),
-            );
+            return const AdaptiveAnimatedCheckmark();
         }
       },
     );


### PR DESCRIPTION
This PR removes `secondaryColor` from the app theme since it can be deferred to the ColorScheme.

It also updates the AnimatedCheckmark to defer to the theme primary color if the color is null.
Lastly a new AdaptiveAnimatedCheckmark was implemented to reduce duplication of the animated checkmark usage.

Part of #145 