### PR TITLE
Platform aware with context

### DIFF
--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -29,12 +29,12 @@ class WeForzaAppState extends ConsumerState<WeForzaApp> {
     ]);
 
     return PlatformAwareWidget(
-      android: () => _buildAndroidWidget(),
-      ios: () => _buildIosWidget(),
+      android: _buildAndroidWidget,
+      ios: _buildIosWidget,
     );
   }
 
-  Widget _buildAndroidWidget() {
+  Widget _buildAndroidWidget(BuildContext context) {
     return MaterialApp(
       title: _appName,
       localizationsDelegates: const [
@@ -49,7 +49,7 @@ class WeForzaAppState extends ConsumerState<WeForzaApp> {
     );
   }
 
-  Widget _buildIosWidget() {
+  Widget _buildIosWidget(BuildContext context) {
     return CupertinoApp(
       title: _appName,
       localizationsDelegates: const [

--- a/lib/widgets/common/file_extension_selection.dart
+++ b/lib/widgets/common/file_extension_selection.dart
@@ -30,8 +30,8 @@ class FileExtensionSelectionState extends State<FileExtensionSelection> {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => _buildAndroidWidget(context),
-      ios: () => _buildIosWidget(context),
+      android: _buildAndroidWidget,
+      ios: _buildIosWidget,
     );
   }
 

--- a/lib/widgets/common/filename_input_field.dart
+++ b/lib/widgets/common/filename_input_field.dart
@@ -62,7 +62,7 @@ class FileNameInputField extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           PlatformAwareWidget(
-            android: () => TextFormField(
+            android: (_) => TextFormField(
               textInputAction: TextInputAction.done,
               keyboardType: TextInputType.text,
               autocorrect: false,
@@ -88,7 +88,7 @@ class FileNameInputField extends StatelessWidget {
               ),
               autovalidateMode: AutovalidateMode.onUserInteraction,
             ),
-            ios: () => CupertinoTextField(
+            ios: (_) => CupertinoTextField(
               textInputAction: TextInputAction.done,
               keyboardType: TextInputType.text,
               placeholder: translator.Filename,
@@ -110,11 +110,11 @@ class FileNameInputField extends StatelessWidget {
             ),
           ),
           PlatformAwareWidget(
-            android: () => ValidationLabel(
+            android: (_) => ValidationLabel(
               stream: errorController,
               style: AppTheme.desctructiveAction.androidMediumErrorStyle,
             ),
-            ios: () => ValidationLabel(
+            ios: (_) => ValidationLabel(
               stream: errorController,
               style: const TextStyle(
                 color: CupertinoColors.destructiveRed,

--- a/lib/widgets/common/form_submit_button.dart
+++ b/lib/widgets/common/form_submit_button.dart
@@ -44,11 +44,11 @@ class _FormSubmitButtonState extends State<FormSubmitButton> {
         const loading = PlatformAwareLoadingIndicator();
 
         final button = PlatformAwareWidget(
-          android: () => ElevatedButton(
+          android: (_) => ElevatedButton(
             onPressed: _onSubmitButtonPressed,
             child: Text(widget.label),
           ),
-          ios: () => CupertinoButton.filled(
+          ios: (_) => CupertinoButton.filled(
             onPressed: _onSubmitButtonPressed,
             child: Text(
               widget.label,

--- a/lib/widgets/common/ride_list_item_attendee_counter.dart
+++ b/lib/widgets/common/ride_list_item_attendee_counter.dart
@@ -78,12 +78,12 @@ class RideListItemAttendeeCounterState
               Padding(
                 padding: const EdgeInsets.only(left: 4),
                 child: PlatformAwareWidget(
-                  android: () => Icon(
+                  android: (_) => Icon(
                     Icons.people,
                     size: widget.iconSize,
                     color: widget.counterStyle?.color,
                   ),
-                  ios: () => Icon(
+                  ios: (_) => Icon(
                     CupertinoIcons.person_2_fill,
                     size: widget.iconSize,
                     color: widget.counterStyle?.color,
@@ -98,13 +98,13 @@ class RideListItemAttendeeCounterState
           dimension: widget.iconSize,
           child: Center(
             child: PlatformAwareWidget(
-              android: () => SizedBox.square(
+              android: (_) => SizedBox.square(
                 dimension: widget.iconSize * .8,
                 child: const Center(
                   child: CircularProgressIndicator(strokeWidth: 2),
                 ),
               ),
-              ios: () => const CupertinoActivityIndicator(radius: 8),
+              ios: (_) => const CupertinoActivityIndicator(radius: 8),
             ),
           ),
         );

--- a/lib/widgets/custom/add_ride_calendar/add_ride_calendar.dart
+++ b/lib/widgets/custom/add_ride_calendar/add_ride_calendar.dart
@@ -22,11 +22,11 @@ class AddRideCalendar extends StatelessWidget {
 
     return DatePicker(
       backButton: PlatformAwareWidget(
-        android: () => IconButton(
+        android: (_) => IconButton(
           icon: const Icon(Icons.arrow_back),
           onPressed: calendarDelegate.goBackOneMonth,
         ),
-        ios: () => CupertinoIconButton(
+        ios: (_) => CupertinoIconButton(
           icon: CupertinoIcons.chevron_left,
           onPressed: calendarDelegate.goBackOneMonth,
         ),
@@ -46,11 +46,11 @@ class AddRideCalendar extends StatelessWidget {
       },
       delegate: calendarDelegate,
       forwardButton: PlatformAwareWidget(
-        android: () => IconButton(
+        android: (_) => IconButton(
           icon: const Icon(Icons.arrow_forward),
           onPressed: calendarDelegate.goForwardOneMonth,
         ),
-        ios: () => CupertinoIconButton(
+        ios: (_) => CupertinoIconButton(
           icon: CupertinoIcons.chevron_right,
           onPressed: calendarDelegate.goForwardOneMonth,
         ),

--- a/lib/widgets/custom/profile_image/profile_image.dart
+++ b/lib/widgets/custom/profile_image/profile_image.dart
@@ -153,13 +153,13 @@ class AdaptiveProfileImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => ProfileImage(
+      android: (_) => ProfileImage(
         icon: Icons.person,
         image: image,
         personInitials: personInitials,
         size: size,
       ),
-      ios: () => ProfileImage(
+      ios: (_) => ProfileImage(
         icon: CupertinoIcons.person_fill,
         image: image,
         personInitials: personInitials,

--- a/lib/widgets/custom/profile_image/profile_image_picker.dart
+++ b/lib/widgets/custom/profile_image/profile_image_picker.dart
@@ -47,13 +47,13 @@ class ProfileImagePicker extends StatelessWidget {
           onTap: delegate.pickImage,
           onLongPress: delegate.clearImage,
           child: PlatformAwareWidget(
-            android: () => _AsyncProfileImage(
+            android: (_) => _AsyncProfileImage(
               future: value.image,
               icon: Icons.camera_alt,
               loading: loading,
               size: size,
             ),
-            ios: () => _AsyncProfileImage(
+            ios: (_) => _AsyncProfileImage(
               future: value.image,
               icon: CupertinoIcons.camera_fill,
               loading: loading,

--- a/lib/widgets/pages/add_ride_form.dart
+++ b/lib/widgets/pages/add_ride_form.dart
@@ -77,8 +77,8 @@ class AddRideFormState extends ConsumerState<AddRideForm> {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => _buildAndroidLayout(context),
-      ios: () => _buildIosLayout(context),
+      android: _buildAndroidLayout,
+      ios: _buildIosLayout,
     );
   }
 
@@ -107,11 +107,11 @@ class _ClearRideSelectionButton extends StatelessWidget {
         }
 
         return PlatformAwareWidget(
-          android: () => IconButton(
+          android: (_) => IconButton(
             icon: const Icon(Icons.delete_sweep),
             onPressed: delegate.clearSelection,
           ),
-          ios: () => CupertinoIconButton(
+          ios: (_) => CupertinoIconButton(
             color: CupertinoColors.systemRed,
             icon: CupertinoIcons.xmark_rectangle_fill,
             onPressed: delegate.clearSelection,
@@ -146,8 +146,8 @@ class _AddRideFormSubmitButtonState extends State<_AddRideFormSubmitButton> {
           child: Text(errorMessage),
         ),
         PlatformAwareWidget(
-          android: () => ElevatedButton(onPressed: onTap, child: Text(label)),
-          ios: () => CupertinoButton.filled(
+          android: (_) => ElevatedButton(onPressed: onTap, child: Text(label)),
+          ios: (_) => CupertinoButton.filled(
             onPressed: onTap,
             child: Text(label, style: const TextStyle(color: Colors.white)),
           ),

--- a/lib/widgets/pages/device_form.dart
+++ b/lib/widgets/pages/device_form.dart
@@ -158,7 +158,7 @@ class DeviceFormState extends ConsumerState<DeviceForm> with DeviceValidator {
     final translator = S.of(context);
 
     return PlatformAwareWidget(
-      android: () => TextFormField(
+      android: (_) => TextFormField(
         focusNode: _deviceNameFocusNode,
         textInputAction: TextInputAction.done,
         keyboardType: TextInputType.text,
@@ -183,7 +183,7 @@ class DeviceFormState extends ConsumerState<DeviceForm> with DeviceValidator {
         ),
         autovalidateMode: AutovalidateMode.onUserInteraction,
       ),
-      ios: () => CupertinoFormField(
+      ios: (_) => CupertinoFormField(
         controller: _deviceNameController,
         errorController: _deviceNameErrorController,
         focusNode: _deviceNameFocusNode,
@@ -219,7 +219,7 @@ class DeviceFormState extends ConsumerState<DeviceForm> with DeviceValidator {
         widget.device == null ? translator.AddDevice : translator.EditDevice;
 
     return PlatformAwareWidget(
-      android: () => FormSubmitButton(
+      android: (context) => FormSubmitButton(
         errorMessageBuilder: (error) => _buildErrorMessage(error, translator),
         label: submitButtonLabel,
         future: _future,
@@ -231,7 +231,7 @@ class DeviceFormState extends ConsumerState<DeviceForm> with DeviceValidator {
           }
         },
       ),
-      ios: () => FormSubmitButton(
+      ios: (context) => FormSubmitButton(
         errorMessageBuilder: (error) => _buildErrorMessage(error, translator),
         label: submitButtonLabel,
         future: _future,
@@ -257,8 +257,8 @@ class DeviceFormState extends ConsumerState<DeviceForm> with DeviceValidator {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => _buildAndroidLayout(context),
-      ios: () => _buildIosLayout(context),
+      android: _buildAndroidLayout,
+      ios: _buildIosLayout,
     );
   }
 

--- a/lib/widgets/pages/export_members_page.dart
+++ b/lib/widgets/pages/export_members_page.dart
@@ -141,7 +141,7 @@ class ExportMembersPageState extends ConsumerState<ExportMembersPage> {
               ),
             ),
             PlatformAwareWidget(
-              android: () => ElevatedButton(
+              android: (_) => ElevatedButton(
                 child: Text(translator.Export),
                 onPressed: () {
                   final formState = _formKey.currentState;
@@ -153,7 +153,7 @@ class ExportMembersPageState extends ConsumerState<ExportMembersPage> {
                   }
                 },
               ),
-              ios: () => CupertinoButton.filled(
+              ios: (_) => CupertinoButton.filled(
                 child: Text(
                   translator.Export,
                   style: const TextStyle(color: Colors.white),
@@ -176,8 +176,8 @@ class ExportMembersPageState extends ConsumerState<ExportMembersPage> {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => _buildAndroidLayout(context),
-      ios: () => _buildIosLayout(context),
+      android: _buildAndroidLayout,
+      ios: _buildIosLayout,
     );
   }
 

--- a/lib/widgets/pages/export_ride_page.dart
+++ b/lib/widgets/pages/export_ride_page.dart
@@ -155,7 +155,7 @@ class ExportRidePageState extends ConsumerState<ExportRidePage> {
               ),
             ),
             PlatformAwareWidget(
-              android: () => ElevatedButton(
+              android: (_) => ElevatedButton(
                 child: Text(translator.Export),
                 onPressed: () {
                   final formState = _formKey.currentState;
@@ -167,7 +167,7 @@ class ExportRidePageState extends ConsumerState<ExportRidePage> {
                   }
                 },
               ),
-              ios: () => CupertinoButton.filled(
+              ios: (_) => CupertinoButton.filled(
                 child: Text(
                   translator.Export,
                   style: const TextStyle(color: Colors.white),
@@ -206,8 +206,8 @@ class ExportRidePageState extends ConsumerState<ExportRidePage> {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => _buildAndroidLayout(context),
-      ios: () => _buildIosLayout(context),
+      android: _buildAndroidLayout,
+      ios: _buildIosLayout,
     );
   }
 

--- a/lib/widgets/pages/home_page.dart
+++ b/lib/widgets/pages/home_page.dart
@@ -45,8 +45,8 @@ class _HomePageState extends State<HomePage>
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => _buildAndroidWidget(context),
-      ios: () => _buildIosWidget(context),
+      android: _buildAndroidWidget,
+      ios: _buildIosWidget,
     );
   }
 

--- a/lib/widgets/pages/import_members_page.dart
+++ b/lib/widgets/pages/import_members_page.dart
@@ -35,12 +35,12 @@ class ImportMembersPageState extends ConsumerState<ImportMembersPage> {
 
   Widget _buildErrorMessage(String errorMessage) {
     return PlatformAwareWidget(
-      android: () => Text(
+      android: (_) => Text(
         errorMessage,
         softWrap: true,
         style: AppTheme.desctructiveAction.androidMediumErrorStyle,
       ),
-      ios: () => Text(
+      ios: (_) => Text(
         errorMessage,
         softWrap: true,
         style: const TextStyle(
@@ -181,8 +181,8 @@ class ImportMembersPageState extends ConsumerState<ImportMembersPage> {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => _buildAndroidWidget(context),
-      ios: () => _buildIosWidget(context),
+      android: _buildAndroidWidget,
+      ios: _buildIosWidget,
     );
   }
 
@@ -205,8 +205,8 @@ class _ImportMembersButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => TextButton(onPressed: onTap, child: Text(text)),
-      ios: () => CupertinoButton.filled(
+      android: (_) => TextButton(onPressed: onTap, child: Text(text)),
+      ios: (_) => CupertinoButton.filled(
         onPressed: onTap,
         child: Text(text, style: const TextStyle(color: Colors.white)),
       ),

--- a/lib/widgets/pages/member_details/member_active_toggle.dart
+++ b/lib/widgets/pages/member_details/member_active_toggle.dart
@@ -23,7 +23,7 @@ class MemberActiveToggle extends StatelessWidget {
               );
 
               return PlatformAwareWidget(
-                android: () => Switch(
+                android: (_) => Switch(
                   value: isActive,
                   onChanged: (value) {
                     final notifier = ref.read(selectedMemberProvider.notifier);
@@ -31,7 +31,7 @@ class MemberActiveToggle extends StatelessWidget {
                     notifier.setMemberActive(value);
                   },
                 ),
-                ios: () => CupertinoSwitch(
+                ios: (_) => CupertinoSwitch(
                   value: isActive,
                   onChanged: (value) {
                     final notifier = ref.read(selectedMemberProvider.notifier);

--- a/lib/widgets/pages/member_details/member_details_page.dart
+++ b/lib/widgets/pages/member_details/member_details_page.dart
@@ -36,8 +36,8 @@ class MemberDetailsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => _buildAndroidLayout(context),
-      ios: () => _buildIOSLayout(context),
+      android: _buildAndroidLayout,
+      ios: _buildIOSLayout,
     );
   }
 

--- a/lib/widgets/pages/member_details/member_devices_list/delete_device_button.dart
+++ b/lib/widgets/pages/member_details/member_devices_list/delete_device_button.dart
@@ -35,11 +35,11 @@ class DeleteDeviceButton extends StatelessWidget {
     final errorStyle = AppTheme.desctructiveAction.androidDefaultErrorStyle;
 
     return PlatformAwareWidget(
-      android: () => IconButton(
+      android: (context) => IconButton(
         icon: Icon(Icons.delete, color: errorStyle.color),
         onPressed: () => _onDeletePressed(context),
       ),
-      ios: () => CupertinoIconButton(
+      ios: (context) => CupertinoIconButton(
         color: CupertinoColors.systemRed,
         icon: CupertinoIcons.delete,
         onPressed: () => _onDeletePressed(context),

--- a/lib/widgets/pages/member_details/member_devices_list/member_devices_list.dart
+++ b/lib/widgets/pages/member_details/member_devices_list/member_devices_list.dart
@@ -99,7 +99,7 @@ class MemberDevicesListState extends ConsumerState<MemberDevicesList> {
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 16),
             child: PlatformAwareWidget(
-              android: () => TextButton(
+              android: (context) => TextButton(
                 onPressed: () {
                   final selectedMember = ref.read(selectedMemberProvider);
 
@@ -107,7 +107,7 @@ class MemberDevicesListState extends ConsumerState<MemberDevicesList> {
                 },
                 child: Text(S.of(context).AddDevice),
               ),
-              ios: () => CupertinoButton.filled(
+              ios: (context) => CupertinoButton.filled(
                 onPressed: () {
                   final selectedMember = ref.read(selectedMemberProvider);
 

--- a/lib/widgets/pages/member_details/member_devices_list/member_devices_list_disabled_item.dart
+++ b/lib/widgets/pages/member_details/member_devices_list/member_devices_list_disabled_item.dart
@@ -37,8 +37,8 @@ class MemberDevicesListDisabledItem extends StatelessWidget {
   // Hence we show whitespace instead, that is the size of the button.
   Widget _buildButtonWhitespace() {
     return PlatformAwareWidget(
-      android: () => SizedBox.fromSize(size: const Size.square(40)),
-      ios: () => SizedBox.fromSize(size: const Size.square(24)),
+      android: (_) => SizedBox.fromSize(size: const Size.square(40)),
+      ios: (_) => SizedBox.fromSize(size: const Size.square(24)),
     );
   }
 }

--- a/lib/widgets/pages/member_details/member_devices_list/member_devices_list_empty.dart
+++ b/lib/widgets/pages/member_details/member_devices_list/member_devices_list_empty.dart
@@ -42,7 +42,7 @@ class MemberDevicesListEmpty extends StatelessWidget {
               Consumer(
                 builder: (context, ref, child) {
                   return PlatformAwareWidget(
-                    android: () => ElevatedButton(
+                    android: (context) => ElevatedButton(
                       onPressed: () {
                         final selectedMember = ref.read(selectedMemberProvider);
 
@@ -50,7 +50,7 @@ class MemberDevicesListEmpty extends StatelessWidget {
                       },
                       child: Text(translator.AddDevice),
                     ),
-                    ios: () => CupertinoButton.filled(
+                    ios: (context) => CupertinoButton.filled(
                       onPressed: () {
                         final selectedMember = ref.read(selectedMemberProvider);
 

--- a/lib/widgets/pages/member_details/member_devices_list/member_devices_list_header.dart
+++ b/lib/widgets/pages/member_details/member_devices_list/member_devices_list_header.dart
@@ -12,11 +12,14 @@ class MemberDevicesListHeader extends StatelessWidget {
     final child = Text(S.of(context).Devices, style: theme.headerStyle);
 
     return PlatformAwareWidget(
-      android: () => Padding(
+      android: (_) => Padding(
         padding: const EdgeInsets.only(top: 4),
         child: child,
       ),
-      ios: () => Padding(padding: const EdgeInsets.only(top: 12), child: child),
+      ios: (_) => Padding(
+        padding: const EdgeInsets.only(top: 12),
+        child: child,
+      ),
     );
   }
 }

--- a/lib/widgets/pages/member_details/member_devices_list/member_devices_list_item.dart
+++ b/lib/widgets/pages/member_details/member_devices_list/member_devices_list_item.dart
@@ -54,11 +54,11 @@ class MemberDevicesListItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => Padding(
+      android: (context) => Padding(
         padding: const EdgeInsets.only(left: 8, right: 4, bottom: 4),
         child: _buildItem(context),
       ),
-      ios: () => Padding(
+      ios: (context) => Padding(
         padding: const EdgeInsets.fromLTRB(4, 16, 16, 16),
         child: _buildItem(context),
       ),
@@ -88,14 +88,14 @@ class _EditDeviceButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return PlatformAwareWidget(
-      android: () => IconButton(
+      android: (context) => IconButton(
         icon: Icon(
           Icons.edit,
           color: AppTheme.memberDevicesList.androidEditDeviceButtonColor,
         ),
         onPressed: () => _onEditDevicePressed(context, ref),
       ),
-      ios: () => CupertinoIconButton(
+      ios: (context) => CupertinoIconButton(
         onPressed: () => _onEditDevicePressed(context, ref),
         icon: CupertinoIcons.pencil,
       ),

--- a/lib/widgets/pages/member_form.dart
+++ b/lib/widgets/pages/member_form.dart
@@ -347,7 +347,7 @@ class MemberFormState extends ConsumerState<MemberForm> with MemberValidator {
         : translator.EditMember;
 
     return PlatformAwareWidget(
-      android: () => FormSubmitButton(
+      android: (context) => FormSubmitButton(
         errorMessageBuilder: (error) => _buildErrorMessage(error, translator),
         label: submitButtonLabel,
         future: _future,
@@ -359,7 +359,7 @@ class MemberFormState extends ConsumerState<MemberForm> with MemberValidator {
           }
         },
       ),
-      ios: () => FormSubmitButton(
+      ios: (context) => FormSubmitButton(
         errorMessageBuilder: (error) => _buildErrorMessage(error, translator),
         label: submitButtonLabel,
         future: _future,
@@ -385,8 +385,8 @@ class MemberFormState extends ConsumerState<MemberForm> with MemberValidator {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => _buildAndroidLayout(context),
-      ios: () => _buildIOSLayout(context),
+      android: _buildAndroidLayout,
+      ios: _buildIOSLayout,
     );
   }
 

--- a/lib/widgets/pages/member_list/member_list_page.dart
+++ b/lib/widgets/pages/member_list/member_list_page.dart
@@ -181,8 +181,8 @@ class MemberListPageState extends ConsumerState<MemberListPage> {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => _buildAndroidWidget(context),
-      ios: () => _buildIosWidget(context),
+      android: _buildAndroidWidget,
+      ios: _buildIosWidget,
     );
   }
 

--- a/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
@@ -83,11 +83,11 @@ class BluetoothDisabledError extends StatelessWidget {
       errorMessage: translator.ScanAbortedBluetoothDisabled,
       iosIcon: Icons.bluetooth_disabled,
       primaryButton: PlatformAwareWidget(
-        android: () => ElevatedButton(
+        android: (_) => ElevatedButton(
           onPressed: () => AppSettings.openBluetoothSettings(),
           child: Text(translator.GoToSettings),
         ),
-        ios: () => CupertinoButton.filled(
+        ios: (_) => CupertinoButton.filled(
           onPressed: () => AppSettings.openBluetoothSettings(),
           child: Text(
             translator.GoToSettings,
@@ -96,11 +96,11 @@ class BluetoothDisabledError extends StatelessWidget {
         ),
       ),
       secondaryButton: PlatformAwareWidget(
-        android: () => TextButton(
+        android: (_) => TextButton(
           onPressed: onRetry,
           child: Text(translator.RetryScan),
         ),
-        ios: () => CupertinoButton(
+        ios: (_) => CupertinoButton(
           onPressed: onRetry,
           child: Text(
             translator.RetryScan,
@@ -125,11 +125,11 @@ class GenericScanError extends StatelessWidget {
       errorMessage: translator.GenericError,
       iosIcon: CupertinoIcons.exclamationmark_triangle_fill,
       primaryButton: PlatformAwareWidget(
-        android: () => ElevatedButton(
+        android: (context) => ElevatedButton(
           child: Text(translator.GoBackToDetailPage),
           onPressed: () => Navigator.of(context).pop(),
         ),
-        ios: () => CupertinoButton.filled(
+        ios: (context) => CupertinoButton.filled(
           child: Text(
             translator.GoBackToDetailPage,
             style: const TextStyle(color: Colors.white),
@@ -156,11 +156,11 @@ class PermissionDeniedError extends StatelessWidget {
       errorMessage: translator.ScanAbortedPermissionDenied,
       iosIcon: CupertinoIcons.exclamationmark_triangle_fill,
       primaryButton: PlatformAwareWidget(
-        android: () => ElevatedButton(
+        android: (_) => ElevatedButton(
           child: Text(translator.GoToSettings),
           onPressed: () => AppSettings.openAppSettings(),
         ),
-        ios: () => CupertinoButton.filled(
+        ios: (_) => CupertinoButton.filled(
           child: Text(
             translator.GoToSettings,
             style: const TextStyle(color: Colors.white),
@@ -169,11 +169,11 @@ class PermissionDeniedError extends StatelessWidget {
         ),
       ),
       secondaryButton: PlatformAwareWidget(
-        android: () => TextButton(
+        android: (context) => TextButton(
           child: Text(translator.GoBack),
           onPressed: () => Navigator.of(context).pop(),
         ),
-        ios: () => CupertinoButton(
+        ios: (context) => CupertinoButton(
           child: Text(
             translator.GoBack,
             style: const TextStyle(color: CupertinoColors.activeBlue),

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_button_bar.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_button_bar.dart
@@ -48,7 +48,7 @@ class ManualSelectionButtonBar extends StatelessWidget {
     );
   }
 
-  Widget _buildIosLayout() {
+  Widget _buildIosLayout(BuildContext context) {
     return CupertinoBottomBar(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
@@ -83,7 +83,7 @@ class ManualSelectionButtonBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => _buildAndroidLayout(context),
+      android: _buildAndroidLayout,
       ios: _buildIosLayout,
     );
   }
@@ -135,8 +135,8 @@ class _RidersIcon extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(right: 4),
       child: PlatformAwareWidget(
-        android: () => const Icon(Icons.people, color: Colors.white),
-        ios: () => const Icon(
+        android: (_) => const Icon(Icons.people, color: Colors.white),
+        ios: (_) => const Icon(
           CupertinoIcons.person_2_fill,
           color: CupertinoColors.activeBlue,
         ),
@@ -157,7 +157,7 @@ class _ScannedRidersLabel extends StatelessWidget {
     const textAlign = TextAlign.right;
 
     return PlatformAwareWidget(
-      android: () => Text(
+      android: (_) => Text(
         label,
         maxLines: maxLines,
         overflow: overflow,
@@ -165,7 +165,7 @@ class _ScannedRidersLabel extends StatelessWidget {
         style: const TextStyle(color: Colors.white),
         textAlign: textAlign,
       ),
-      ios: () => Text(
+      ios: (_) => Text(
         label,
         maxLines: maxLines,
         overflow: overflow,

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list.dart
@@ -109,7 +109,7 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
       child: Column(
         children: <Widget>[
           PlatformAwareWidget(
-            android: () => TextFormField(
+            android: (_) => TextFormField(
               textInputAction: TextInputAction.search,
               keyboardType: TextInputType.text,
               autocorrect: false,
@@ -123,7 +123,7 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
                 floatingLabelBehavior: FloatingLabelBehavior.never,
               ),
             ),
-            ios: () => Padding(
+            ios: (_) => Padding(
               padding: const EdgeInsets.all(8),
               child: CupertinoSearchTextField(
                 suffixIcon: const Icon(CupertinoIcons.search),

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_empty.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_empty.dart
@@ -28,11 +28,11 @@ class ManualSelectionListEmpty extends StatelessWidget {
           ),
         ),
         PlatformAwareWidget(
-          android: () => ElevatedButton(
+          android: (context) => ElevatedButton(
             child: Text(translator.GoBack),
             onPressed: () => Navigator.of(context).pop(),
           ),
-          ios: () => CupertinoButton.filled(
+          ios: (context) => CupertinoButton.filled(
             child: Text(
               translator.GoBack,
               style: const TextStyle(color: Colors.white),

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_save_button.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_save_button.dart
@@ -45,14 +45,14 @@ class _ManualSelectionSaveButtonState extends State<ManualSelectionSaveButton> {
         }
 
         final loadingIndicator = PlatformAwareWidget(
-          android: () => const SizedBox.square(
+          android: (_) => const SizedBox.square(
             dimension: 30,
             child: CircularProgressIndicator(
               color: Colors.white,
               strokeWidth: 3,
             ),
           ),
-          ios: () => const CupertinoActivityIndicator(),
+          ios: (_) => const CupertinoActivityIndicator(),
         );
 
         if (snapshot.connectionState == ConnectionState.done) {
@@ -82,7 +82,7 @@ class _SaveButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () {
+      android: (_) {
         final style = ElevatedButton.styleFrom(
           backgroundColor: AppTheme.manualSelectionBottomBar.saveButtonColor,
           foregroundColor: Colors.white,
@@ -93,7 +93,7 @@ class _SaveButton extends StatelessWidget {
           child: ElevatedButton(onPressed: onPressed, child: Text(text)),
         );
       },
-      ios: () => CupertinoButton.filled(
+      ios: (_) => CupertinoButton.filled(
         onPressed: onPressed,
         padding: const EdgeInsets.symmetric(horizontal: 24),
         child: Text(

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/show_scanned_results_toggle.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/show_scanned_results_toggle.dart
@@ -31,7 +31,7 @@ class ShowScannedResultsToggle extends StatelessWidget {
         final showScannedResults = snapshot.data!;
 
         return PlatformAwareWidget(
-          android: () {
+          android: (_) {
             const theme = AppTheme.manualSelectionBottomBar;
 
             return Switch(
@@ -41,7 +41,7 @@ class ShowScannedResultsToggle extends StatelessWidget {
               value: showScannedResults,
             );
           },
-          ios: () => CupertinoSwitch(
+          ios: (_) => CupertinoSwitch(
             onChanged: onChanged,
             value: showScannedResults,
           ),

--- a/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_page.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_page.dart
@@ -139,8 +139,8 @@ class RideAttendeeScanningPageState
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => _buildAndroidLayout(context),
-      ios: () => _buildIOSLayout(context),
+      android: _buildAndroidLayout,
+      ios: _buildIOSLayout,
     );
   }
 

--- a/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_stepper.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_stepper.dart
@@ -51,12 +51,12 @@ class RideAttendeeScanningStepper extends StatelessWidget {
             snapshot.data != RideAttendeeScanningState.manualSelection;
 
         return PlatformAwareWidget(
-          android: () => _buildStepper(
+          android: (context) => _buildStepper(
             context,
             AppTheme.scanStepper.android,
             isScanningStep,
           ),
-          ios: () => _buildStepper(
+          ios: (context) => _buildStepper(
             context,
             AppTheme.scanStepper.ios,
             isScanningStep,

--- a/lib/widgets/pages/ride_attendee_scanning_page/scan_button.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/scan_button.dart
@@ -16,14 +16,14 @@ class ScanButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return SafeArea(
       child: PlatformAwareWidget(
-        android: () => Padding(
+        android: (_) => Padding(
           padding: const EdgeInsets.only(top: 16, bottom: 32),
           child: ElevatedButton(
             onPressed: onPressed,
             child: Text(text),
           ),
         ),
-        ios: () => Padding(
+        ios: (_) => Padding(
           padding: const EdgeInsets.symmetric(vertical: 16),
           child: CupertinoButton.filled(
             onPressed: onPressed,

--- a/lib/widgets/pages/ride_attendee_scanning_page/scan_progress_indicator.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/scan_progress_indicator.dart
@@ -39,7 +39,7 @@ class ScanProgressIndicator extends StatelessWidget {
                 final progress = animationController.value;
 
                 return PlatformAwareWidget(
-                  android: () {
+                  android: (_) {
                     final theme = AppTheme.scanProgressIndicator.android;
 
                     return LinearProgressIndicator(
@@ -50,7 +50,7 @@ class ScanProgressIndicator extends StatelessWidget {
                       ),
                     );
                   },
-                  ios: () {
+                  ios: (_) {
                     final theme = AppTheme.scanProgressIndicator.ios;
 
                     return LinearProgressIndicator(

--- a/lib/widgets/pages/ride_attendee_scanning_page/scan_results_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/scan_results_list.dart
@@ -166,11 +166,11 @@ class _ScanResultsListItem extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.only(right: 4),
               child: PlatformAwareWidget(
-                android: () => const Icon(
+                android: (_) => const Icon(
                   Icons.device_unknown,
                   color: Colors.grey,
                 ),
-                ios: () => const Icon(
+                ios: (_) => const Icon(
                   Icons.device_unknown,
                   color: CupertinoColors.systemGrey,
                 ),

--- a/lib/widgets/pages/ride_details/ride_details_attendees/ride_details_attendees_list.dart
+++ b/lib/widgets/pages/ride_details/ride_details_attendees/ride_details_attendees_list.dart
@@ -150,12 +150,12 @@ class _ScannedAttendeesBottomBar extends ConsumerWidget {
     );
 
     return PlatformAwareWidget(
-      android: () => _buildAndroidLayout(
+      android: (context) => _buildAndroidLayout(
         context,
         scannedAttendees: scannedAttendees,
         total: total,
       ),
-      ios: () => _buildIosLayout(
+      ios: (context) => _buildIosLayout(
         context,
         scannedAttendees: scannedAttendees,
         total: total,

--- a/lib/widgets/pages/ride_details/ride_details_page.dart
+++ b/lib/widgets/pages/ride_details/ride_details_page.dart
@@ -53,8 +53,8 @@ class RideDetailsPageState extends ConsumerState<RideDetailsPage> {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => _buildAndroidLayout(context),
-      ios: () => _buildIOSLayout(context),
+      android: _buildAndroidLayout,
+      ios: _buildIOSLayout,
     );
   }
 

--- a/lib/widgets/pages/ride_list/ride_list_item.dart
+++ b/lib/widgets/pages/ride_list/ride_list_item.dart
@@ -53,8 +53,8 @@ class RideListItem extends ConsumerWidget {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       child: PlatformAwareWidget(
-        android: () => ListTile(title: content),
-        ios: () => Padding(
+        android: (_) => ListTile(title: content),
+        ios: (_) => Padding(
           padding: const EdgeInsets.all(12),
           child: content,
         ),

--- a/lib/widgets/pages/ride_list/ride_list_page.dart
+++ b/lib/widgets/pages/ride_list/ride_list_page.dart
@@ -13,8 +13,8 @@ class RideListPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => _buildAndroidWidget(context),
-      ios: () => _buildIosWidget(context),
+      android: _buildAndroidWidget,
+      ios: _buildIosWidget,
     );
   }
 

--- a/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
@@ -98,12 +98,12 @@ class _AddExcludedTermSuffixIcon extends StatelessWidget {
         }
 
         return PlatformAwareWidget(
-          android: () => IconButton(
+          android: (_) => IconButton(
             color: Colors.blue,
             icon: const Icon(Icons.check),
             onPressed: onTap,
           ),
-          ios: () => CupertinoIconButton(
+          ios: (_) => CupertinoIconButton(
             color: CupertinoColors.activeBlue,
             icon: CupertinoIcons.checkmark_alt,
             onPressed: onTap,

--- a/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field.dart
@@ -182,7 +182,7 @@ class _EditExcludedTermInputFieldButtonBar extends StatelessWidget {
       animation: controller,
       // The delete button is always shown.
       child: PlatformAwareWidget(
-        android: () {
+        android: (context) {
           return IconButton(
             icon: Icon(
               Icons.delete,
@@ -192,7 +192,7 @@ class _EditExcludedTermInputFieldButtonBar extends StatelessWidget {
             padding: EdgeInsets.zero,
           );
         },
-        ios: () => CupertinoIconButton(
+        ios: (context) => CupertinoIconButton(
           color: CupertinoColors.systemRed,
           icon: CupertinoIcons.delete,
           onPressed: () => onDeletePressed(context),
@@ -204,12 +204,12 @@ class _EditExcludedTermInputFieldButtonBar extends StatelessWidget {
         final isValid = validator(context, currentValue.text) == null;
 
         final confirmButton = PlatformAwareWidget(
-          android: () => IconButton(
+          android: (_) => IconButton(
             color: Colors.blue,
             icon: const Icon(Icons.check),
             onPressed: isValid ? () => onConfirmPressed(currentValue) : null,
           ),
-          ios: () => CupertinoIconButton(
+          ios: (_) => CupertinoIconButton(
             color: CupertinoColors.activeBlue,
             icon: CupertinoIcons.checkmark_alt,
             onPressed: isValid ? () => onConfirmPressed(currentValue) : null,
@@ -218,12 +218,12 @@ class _EditExcludedTermInputFieldButtonBar extends StatelessWidget {
 
         // The undo button is disabled if the value is the same.
         final undoButton = PlatformAwareWidget(
-          android: () => IconButton(
+          android: (_) => IconButton(
             color: Colors.black,
             icon: const Icon(Icons.undo),
             onPressed: currentValue.text == term ? null : onUndoPressed,
           ),
-          ios: () => CupertinoIconButton(
+          ios: (_) => CupertinoIconButton(
             color: CupertinoColors.black,
             icon: CupertinoIcons.arrow_counterclockwise,
             onPressed: currentValue.text == term ? null : onUndoPressed,

--- a/lib/widgets/pages/settings/excluded_terms/excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/excluded_term_input_field.dart
@@ -82,7 +82,7 @@ class ExcludedTermInputField extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => TextFormField(
+      android: (_) => TextFormField(
         key: textFieldKey,
         autovalidateMode: AutovalidateMode.onUserInteraction,
         buildCounter: _buildCounter,
@@ -106,7 +106,7 @@ class ExcludedTermInputField extends StatelessWidget {
         textInputAction: TextInputAction.done,
         validator: validator,
       ),
-      ios: () {
+      ios: (_) {
         final child = CupertinoTextFormFieldRow(
           key: textFieldKey,
           autovalidateMode: AutovalidateMode.onUserInteraction,

--- a/lib/widgets/pages/settings/excluded_terms/excluded_terms_list_empty.dart
+++ b/lib/widgets/pages/settings/excluded_terms/excluded_terms_list_empty.dart
@@ -12,7 +12,7 @@ class ExcludedTermsListEmpty extends StatelessWidget {
     final text = S.of(context).NoDisallowedWords;
 
     return PlatformAwareWidget(
-      android: () => Padding(
+      android: (context) => Padding(
         padding: const EdgeInsets.all(4),
         child: Text(
           text,
@@ -20,7 +20,7 @@ class ExcludedTermsListEmpty extends StatelessWidget {
           textAlign: TextAlign.center,
         ),
       ),
-      ios: () {
+      ios: (context) {
         final textStyle = CupertinoTheme.of(context).textTheme.textStyle;
 
         return Container(

--- a/lib/widgets/pages/settings/member_list_filter.dart
+++ b/lib/widgets/pages/settings/member_list_filter.dart
@@ -29,7 +29,7 @@ class MemberListFilter extends StatelessWidget {
         final currentFilter = snapshot.data!;
 
         return PlatformAwareWidget(
-          android: () => Row(
+          android: (_) => Row(
             children: [
               ChoiceChip(
                 label: Text(translator.All),
@@ -63,7 +63,7 @@ class MemberListFilter extends StatelessWidget {
               ),
             ],
           ),
-          ios: () => CupertinoSlidingSegmentedControl<MemberFilterOption>(
+          ios: (_) => CupertinoSlidingSegmentedControl<MemberFilterOption>(
             groupValue: currentFilter,
             onValueChanged: (MemberFilterOption? value) {
               if (value != null) {

--- a/lib/widgets/pages/settings/reset_ride_calendar_button.dart
+++ b/lib/widgets/pages/settings/reset_ride_calendar_button.dart
@@ -20,12 +20,12 @@ class ResetRideCalendarButton extends ConsumerWidget {
 
   Widget _buildButton(BuildContext context, {bool enabled = true}) {
     return PlatformAwareWidget(
-      android: () => ElevatedButton(
+      android: (context) => ElevatedButton(
         style: AppTheme.desctructiveAction.elevatedButtonTheme,
         onPressed: enabled ? () => _showResetCalendarDialog(context) : null,
         child: Text(S.of(context).ResetRideCalendar),
       ),
-      ios: () => CupertinoButton(
+      ios: (context) => CupertinoButton(
         borderRadius: BorderRadius.zero,
         padding: EdgeInsets.zero,
         onPressed: enabled ? () => _showResetCalendarDialog(context) : null,

--- a/lib/widgets/pages/settings/scan_duration_option.dart
+++ b/lib/widgets/pages/settings/scan_duration_option.dart
@@ -44,7 +44,7 @@ class ScanDurationOption extends StatelessWidget {
     final translator = S.of(context);
 
     return PlatformAwareWidget(
-      android: () => Column(
+      android: (context) => Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -69,7 +69,7 @@ class ScanDurationOption extends StatelessWidget {
           Center(child: _buildCurrentDurationLabel()),
         ],
       ),
-      ios: () => CupertinoFormRow(
+      ios: (_) => CupertinoFormRow(
         helper: Padding(
           padding: const EdgeInsets.only(top: 8),
           child: Row(

--- a/lib/widgets/pages/settings/settings_page.dart
+++ b/lib/widgets/pages/settings/settings_page.dart
@@ -95,8 +95,8 @@ class SettingsPageState extends ConsumerState<SettingsPage>
   Widget build(BuildContext context) {
     return FocusAbsorber(
       child: PlatformAwareWidget(
-        android: () => _buildAndroidWidget(context),
-        ios: () => _buildIosWidget(context),
+        android: _buildAndroidWidget,
+        ios: _buildIosWidget,
       ),
     );
   }

--- a/lib/widgets/pages/settings/settings_submit.dart
+++ b/lib/widgets/pages/settings/settings_submit.dart
@@ -14,11 +14,11 @@ class SettingsSubmit extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(right: 8),
       child: PlatformAwareWidget(
-        android: () => Icon(
+        android: (_) => Icon(
           Icons.warning,
           color: Colors.orange.shade200,
         ),
-        ios: () => const Icon(
+        ios: (_) => const Icon(
           CupertinoIcons.exclamationmark_triangle_fill,
           color: CupertinoColors.activeOrange,
         ),
@@ -28,11 +28,11 @@ class SettingsSubmit extends StatelessWidget {
 
   Widget _buildSubmitButton() {
     return PlatformAwareWidget(
-      android: () => IconButton(
+      android: (_) => IconButton(
         icon: const Icon(Icons.done),
         onPressed: onSaveSettings,
       ),
-      ios: () => CupertinoIconButton(
+      ios: (_) => CupertinoIconButton(
         icon: CupertinoIcons.checkmark_alt,
         onPressed: onSaveSettings,
       ),
@@ -54,10 +54,10 @@ class SettingsSubmit extends StatelessWidget {
               padding: const EdgeInsets.only(right: 8),
               child: Center(
                 child: PlatformAwareWidget(
-                  android: () => const CircularProgressIndicator(
+                  android: (_) => const CircularProgressIndicator(
                     valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
                   ),
-                  ios: () => const CupertinoActivityIndicator(),
+                  ios: (_) => const CupertinoActivityIndicator(),
                 ),
               ),
             );

--- a/lib/widgets/platform/platform_aware_icon.dart
+++ b/lib/widgets/platform/platform_aware_icon.dart
@@ -35,8 +35,8 @@ class PlatformAwareIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => Icon(androidIcon, color: androidColor, size: size),
-      ios: () => Icon(iosIcon, color: iosColor, size: size),
+      android: (_) => Icon(androidIcon, color: androidColor, size: size),
+      ios: (_) => Icon(iosIcon, color: iosColor, size: size),
     );
   }
 }

--- a/lib/widgets/platform/platform_aware_loading_indicator.dart
+++ b/lib/widgets/platform/platform_aware_loading_indicator.dart
@@ -9,8 +9,8 @@ class PlatformAwareLoadingIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: () => const CircularProgressIndicator(),
-      ios: () => const CupertinoActivityIndicator(),
+      android: (_) => const CircularProgressIndicator(),
+      ios: (_) => const CupertinoActivityIndicator(),
     );
   }
 }

--- a/lib/widgets/platform/platform_aware_widget.dart
+++ b/lib/widgets/platform/platform_aware_widget.dart
@@ -13,10 +13,10 @@ class PlatformAwareWidget extends StatelessWidget {
   });
 
   /// The builder that is invoked for [TargetPlatform.android].
-  final Widget Function() android;
+  final WidgetBuilder android;
 
   /// The builder that is invoked for [TargetPlatform.iOS].
-  final Widget Function() ios;
+  final WidgetBuilder ios;
 
   @override
   Widget build(BuildContext context) {
@@ -24,9 +24,9 @@ class PlatformAwareWidget extends StatelessWidget {
 
     switch (targetPlatform) {
       case TargetPlatform.android:
-        return android();
+        return android(context);
       case TargetPlatform.iOS:
-        return ios();
+        return ios(context);
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.macOS:


### PR DESCRIPTION
This PR updates `PlatformAwareWidget` to pass its `BuildContext` to its builder functions.

The usages have been updates to use tear-offs or accept the new parameter.

Fixes #200 