### PR TITLE
fix regression in writing milliseconds to file; add test

### DIFF
--- a/lib/extensions/date_extension.dart
+++ b/lib/extensions/date_extension.dart
@@ -4,7 +4,7 @@ extension ToStringNoMillis on DateTime {
   String toStringWithoutMilliseconds() {
     final String s = toString();
 
-    // Strip the milliseconds.
-    return s.substring(0, s.length - 5);
+    // Strip the milliseconds and the trailing Z for UTC dates.
+    return s.substring(0, s.length - (isUtc ? 5 : 4));
   }
 }

--- a/test/date_extension_test.dart
+++ b/test/date_extension_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:weforza/extensions/date_extension.dart';
+
+void main() {
+  group('date extension test', () {
+    test('toStringWithoutMilliseconds - UTC', () {
+      final date = DateTime.utc(1989, 11, 9, 2, 10, 59, 100);
+
+      expect(
+        date.toStringWithoutMilliseconds(),
+        '1989-11-09 02:10:59',
+      );
+    });
+
+    test('toStringWithoutMilliseconds - local time', () {
+      final date = DateTime(1989, 11, 9, 2, 10, 59, 100);
+
+      expect(
+        date.toStringWithoutMilliseconds(),
+        '1989-11-09 02:10:59',
+      );
+    });
+  });
+}


### PR DESCRIPTION
This PR fixes a regression with the date time extension which broke importing riders