### PR TITLE
Migrate Android color scheme to `ColorScheme.fromSeed()`

### DIFF
--- a/lib/widgets/common/device_icon.dart
+++ b/lib/widgets/common/device_icon.dart
@@ -1,6 +1,6 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:weforza/model/device_type.dart';
-import 'package:weforza/widgets/theme.dart';
 
 class DeviceIcon extends StatelessWidget {
   const DeviceIcon({super.key, this.size, required this.type});
@@ -11,21 +11,19 @@ class DeviceIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    switch (Theme.of(context).platform) {
+    final theme = Theme.of(context);
+
+    switch (theme.platform) {
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        return Icon(
-          type.icon,
-          color: AppTheme.deviceTypePicker.android.selectedColor,
-          size: size,
-        );
+        return Icon(type.icon, color: theme.primaryColor, size: size);
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         return Icon(
           type.icon,
-          color: AppTheme.deviceTypePicker.ios.selectedColor,
+          color: CupertinoTheme.of(context).primaryColor,
           size: size,
         );
     }

--- a/lib/widgets/common/filename_input_field.dart
+++ b/lib/widgets/common/filename_input_field.dart
@@ -4,7 +4,6 @@ import 'package:rxdart/rxdart.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/widgets/common/validation_label.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
-import 'package:weforza/widgets/theme.dart';
 
 class FileNameInputField extends StatelessWidget {
   FileNameInputField({
@@ -110,10 +109,16 @@ class FileNameInputField extends StatelessWidget {
             ),
           ),
           PlatformAwareWidget(
-            android: (_) => ValidationLabel(
-              stream: errorController,
-              style: AppTheme.desctructiveAction.androidMediumErrorStyle,
-            ),
+            android: (context) {
+              final theme = Theme.of(context);
+
+              return ValidationLabel(
+                stream: errorController,
+                style: theme.textTheme.labelMedium!.copyWith(
+                  color: theme.errorColor,
+                ),
+              );
+            },
             ios: (_) => ValidationLabel(
               stream: errorController,
               style: const TextStyle(

--- a/lib/widgets/common/form_submit_button.dart
+++ b/lib/widgets/common/form_submit_button.dart
@@ -50,10 +50,7 @@ class _FormSubmitButtonState extends State<FormSubmitButton> {
           ),
           ios: (_) => CupertinoButton.filled(
             onPressed: _onSubmitButtonPressed,
-            child: Text(
-              widget.label,
-              style: const TextStyle(color: Colors.white),
-            ),
+            child: Text(widget.label),
           ),
         );
 

--- a/lib/widgets/common/member_name_and_alias.dart
+++ b/lib/widgets/common/member_name_and_alias.dart
@@ -2,16 +2,26 @@ import 'package:flutter/material.dart';
 
 /// This widget displays the first name, alias and last name of a member.
 class MemberNameAndAlias extends StatelessWidget {
-  const MemberNameAndAlias({
+  const MemberNameAndAlias.singleLine({
     super.key,
     required this.alias,
     required this.firstName,
+    required this.lastName,
+    this.overflow = TextOverflow.ellipsis,
+    required TextStyle style,
+  })  : _isTwoLine = false,
+        firstLineStyle = style,
+        secondLineStyle = null;
+
+  const MemberNameAndAlias.twoLines({
+    super.key,
+    required this.alias,
     required this.firstLineStyle,
-    this.isTwoLine = true,
+    required this.firstName,
     required this.lastName,
     this.overflow = TextOverflow.ellipsis,
     required this.secondLineStyle,
-  });
+  }) : _isTwoLine = true;
 
   /// The alias to display.
   final String alias;
@@ -32,7 +42,7 @@ class MemberNameAndAlias extends StatelessWidget {
   ///
   /// If this is false, the first name, alias and last name are displayed
   /// one after another on a single line.
-  final bool isTwoLine;
+  final bool _isTwoLine;
 
   /// The last name to display.
   final String lastName;
@@ -41,17 +51,14 @@ class MemberNameAndAlias extends StatelessWidget {
   final TextOverflow overflow;
 
   /// The style for the second line.
-  ///
-  /// If [isTwoLine] is true, this is the style for the last name.
-  /// Otherwise this style is ignored.
-  final TextStyle secondLineStyle;
+  final TextStyle? secondLineStyle;
 
   @override
   Widget build(BuildContext context) {
     final defaultStyle = DefaultTextStyle.of(context).style;
     final effectiveFirstLineStyle = defaultStyle.merge(firstLineStyle);
 
-    if (isTwoLine) {
+    if (_isTwoLine) {
       return Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/widgets/custom/device_type_carousel.dart
+++ b/lib/widgets/custom/device_type_carousel.dart
@@ -1,8 +1,8 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/model/device_type.dart';
 import 'package:weforza/widgets/common/device_icon.dart';
-import 'package:weforza/widgets/theme.dart';
 
 /// This widget represents a carousel for selecting a device type.
 class DeviceTypeCarousel extends StatelessWidget {
@@ -89,18 +89,25 @@ class _DeviceTypeCarouselDot extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    DeviceTypePickerTheme theme;
+    Color color;
 
-    switch (Theme.of(context).platform) {
+    final theme = Theme.of(context);
+
+    switch (theme.platform) {
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        theme = AppTheme.deviceTypePicker.android;
+        color = selected
+            ? theme.primaryColor
+            : theme.disabledColor.withOpacity(0.2);
         break;
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
-        theme = AppTheme.deviceTypePicker.ios;
+        final cupertinoTheme = CupertinoTheme.of(context);
+        color = selected
+            ? cupertinoTheme.primaryColor
+            : CupertinoColors.systemGrey4;
         break;
     }
 
@@ -111,7 +118,7 @@ class _DeviceTypeCarouselDot extends StatelessWidget {
         height: 12,
         decoration: BoxDecoration(
           borderRadius: const BorderRadius.all(Radius.circular(6)),
-          color: selected ? theme.selectedColor : theme.unselectedColor,
+          color: color,
         ),
       ),
     );

--- a/lib/widgets/custom/profile_image/profile_image.dart
+++ b/lib/widgets/custom/profile_image/profile_image.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
-import 'package:weforza/widgets/theme.dart';
 
 /// This widget represents a profile image.
 ///
@@ -15,23 +14,15 @@ class ProfileImage extends StatelessWidget {
   /// The default constructor.
   const ProfileImage({
     super.key,
-    this.backgroundColor,
     required this.icon,
-    this.iconColor,
     this.image,
     this.loading,
     this.personInitials,
     this.size = 40,
   });
 
-  /// The background color for [icon].
-  final Color? backgroundColor;
-
   /// The icon to use as placeholder if [personInitials] is null or empty.
   final IconData icon;
-
-  /// The color for [icon].
-  final Color? iconColor;
 
   /// The profile image to show.
   final File? image;
@@ -49,8 +40,37 @@ class ProfileImage extends StatelessWidget {
   /// Defaults to 40.
   final double size;
 
-  Widget _buildPlaceholder() {
+  Widget _buildPlaceholder(BuildContext context) {
     final initials = personInitials;
+    final theme = Theme.of(context);
+    List<Color> backgroundColors;
+    Color placeholderBackgroundColor;
+
+    switch (theme.platform) {
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        backgroundColors = Colors.primaries;
+        placeholderBackgroundColor = theme.primaryColor;
+        break;
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        backgroundColors = [
+          // CupertinoColors.systemBlue is excluded, to prevent contrast issues
+          // with CupertinoTheme.primaryColor.
+          CupertinoColors.systemGreen,
+          CupertinoColors.systemIndigo,
+          CupertinoColors.systemOrange,
+          CupertinoColors.systemPink,
+          CupertinoColors.systemPurple,
+          CupertinoColors.systemRed,
+          CupertinoColors.systemTeal,
+          CupertinoColors.systemYellow,
+        ];
+        placeholderBackgroundColor = CupertinoTheme.of(context).primaryColor;
+        break;
+    }
 
     if (initials == null || initials.isEmpty) {
       return Container(
@@ -58,9 +78,11 @@ class ProfileImage extends StatelessWidget {
         width: size,
         decoration: BoxDecoration(
           borderRadius: BorderRadius.all(Radius.circular(size / 2)),
-          color: backgroundColor,
+          color: placeholderBackgroundColor,
         ),
-        child: Center(child: Icon(icon, color: iconColor, size: .7 * size)),
+        child: Center(
+          child: Icon(icon, color: Colors.white, size: .7 * size),
+        ),
       );
     }
 
@@ -69,32 +91,30 @@ class ProfileImage extends StatelessWidget {
       width: size,
       decoration: BoxDecoration(
         borderRadius: BorderRadius.all(Radius.circular(size / 2)),
-        color: _getBackgroundColor(initials),
+        color: _getBackgroundColor(initials, backgroundColors),
       ),
       child: Center(
         child: Text(
           personInitials!.toUpperCase(),
-          style: AppTheme.profileImagePlaceholder.initialsStyle.copyWith(
-            fontSize: size / 2,
-          ),
+          style: TextStyle(color: Colors.white, fontSize: size / 2),
         ),
       ),
     );
   }
 
-  Color _getBackgroundColor(String initials) {
+  Color _getBackgroundColor(String initials, List<Color> colors) {
     int index = initials.codeUnitAt(0);
 
     if (initials.length == 2) {
       index += initials.codeUnitAt(1);
     }
 
-    return Colors.primaries[index % Colors.primaries.length];
+    return colors[index % colors.length];
   }
 
   @override
   Widget build(BuildContext context) {
-    final placeholder = _buildPlaceholder();
+    final placeholder = _buildPlaceholder(context);
 
     if (image == null) {
       return placeholder;

--- a/lib/widgets/custom/profile_image/profile_image_picker.dart
+++ b/lib/widgets/custom/profile_image/profile_image_picker.dart
@@ -7,7 +7,6 @@ import 'package:weforza/model/profile_image_picker_delegate.dart';
 import 'package:weforza/widgets/custom/profile_image/profile_image.dart';
 import 'package:weforza/widgets/platform/platform_aware_loading_indicator.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
-import 'package:weforza/widgets/theme.dart';
 
 class ProfileImagePicker extends StatelessWidget {
   const ProfileImagePicker({
@@ -88,14 +87,10 @@ class _AsyncProfileImage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const theme = AppTheme.profileImagePlaceholder;
-
     return FutureBuilder<File?>(
       future: future,
       builder: (context, snapshot) => ProfileImage(
-        backgroundColor: theme.backgroundColor,
         icon: icon,
-        iconColor: theme.iconColor,
         image: snapshot.data,
         loading: loading,
         size: size,

--- a/lib/widgets/dialogs/dialogs.dart
+++ b/lib/widgets/dialogs/dialogs.dart
@@ -140,11 +140,11 @@ class WeforzaAlertDialog extends StatelessWidget {
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
+        final styles = Theme.of(context).extension<DestructiveButtons>()!;
+
         return TextButton(
           onPressed: onPressed,
-          style: isDestructive
-              ? AppTheme.desctructiveAction.textButtonTheme
-              : null,
+          style: isDestructive ? styles.textButtonStyle : null,
           child: Text(label),
         );
       case TargetPlatform.iOS:

--- a/lib/widgets/pages/add_ride_form.dart
+++ b/lib/widgets/pages/add_ride_form.dart
@@ -149,7 +149,7 @@ class _AddRideFormSubmitButtonState extends State<_AddRideFormSubmitButton> {
           android: (_) => ElevatedButton(onPressed: onTap, child: Text(label)),
           ios: (_) => CupertinoButton.filled(
             onPressed: onTap,
-            child: Text(label, style: const TextStyle(color: Colors.white)),
+            child: Text(label),
           ),
         ),
       ],

--- a/lib/widgets/pages/export_members_page.dart
+++ b/lib/widgets/pages/export_members_page.dart
@@ -155,10 +155,7 @@ class ExportMembersPageState extends ConsumerState<ExportMembersPage> {
                 },
               ),
               ios: (_) => CupertinoButton.filled(
-                child: Text(
-                  translator.Export,
-                  style: const TextStyle(color: Colors.white),
-                ),
+                child: Text(translator.Export),
                 onPressed: () {
                   if (_filenameErrorController.value.isEmpty) {
                     _exportFuture = _submitForm(translator);

--- a/lib/widgets/pages/export_ride_page.dart
+++ b/lib/widgets/pages/export_ride_page.dart
@@ -169,10 +169,7 @@ class ExportRidePageState extends ConsumerState<ExportRidePage> {
                 },
               ),
               ios: (_) => CupertinoButton.filled(
-                child: Text(
-                  translator.Export,
-                  style: const TextStyle(color: Colors.white),
-                ),
+                child: Text(translator.Export),
                 onPressed: () {
                   if (_filenameErrorController.value.isEmpty) {
                     _exportFuture = _submitForm(translator);

--- a/lib/widgets/pages/import_riders_page.dart
+++ b/lib/widgets/pages/import_riders_page.dart
@@ -11,7 +11,6 @@ import 'package:weforza/widgets/common/progress_indicator_with_label.dart';
 import 'package:weforza/widgets/custom/animated_checkmark.dart';
 import 'package:weforza/widgets/platform/platform_aware_loading_indicator.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
-import 'package:weforza/widgets/theme.dart';
 
 class ImportRidersPage extends ConsumerStatefulWidget {
   const ImportRidersPage({super.key});
@@ -157,22 +156,28 @@ class _ImportRidersButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: (_) => Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Padding(
-            padding: const EdgeInsets.only(bottom: 8),
-            child: TextButton(onPressed: onPressed, child: Text(label)),
-          ),
-          Flexible(
-            child: Text(
-              errorMessage ?? '',
-              style: AppTheme.desctructiveAction.androidMediumErrorStyle,
+      android: (context) {
+        final theme = Theme.of(context);
+
+        return Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: TextButton(onPressed: onPressed, child: Text(label)),
             ),
-          ),
-        ],
-      ),
+            Flexible(
+              child: Text(
+                errorMessage ?? '',
+                style: theme.textTheme.labelMedium!.copyWith(
+                  color: theme.errorColor,
+                ),
+              ),
+            ),
+          ],
+        );
+      },
       ios: (_) => Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [

--- a/lib/widgets/pages/member_details/member_devices_list/delete_device_button.dart
+++ b/lib/widgets/pages/member_details/member_devices_list/delete_device_button.dart
@@ -4,7 +4,6 @@ import 'package:weforza/widgets/dialogs/delete_device_dialog.dart';
 import 'package:weforza/widgets/dialogs/dialogs.dart';
 import 'package:weforza/widgets/platform/cupertino_icon_button.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
-import 'package:weforza/widgets/theme.dart';
 
 class DeleteDeviceButton extends StatelessWidget {
   const DeleteDeviceButton({
@@ -32,11 +31,9 @@ class DeleteDeviceButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final errorStyle = AppTheme.desctructiveAction.androidDefaultErrorStyle;
-
     return PlatformAwareWidget(
       android: (context) => IconButton(
-        icon: Icon(Icons.delete, color: errorStyle.color),
+        icon: Icon(Icons.delete, color: Theme.of(context).errorColor),
         onPressed: () => _onDeletePressed(context),
       ),
       ios: (context) => CupertinoIconButton(

--- a/lib/widgets/pages/member_details/member_devices_list/member_devices_list.dart
+++ b/lib/widgets/pages/member_details/member_devices_list/member_devices_list.dart
@@ -113,10 +113,7 @@ class MemberDevicesListState extends ConsumerState<MemberDevicesList> {
 
                   onAddDevicePressed(context, selectedMember!.uuid);
                 },
-                child: Text(
-                  S.of(context).AddDevice,
-                  style: const TextStyle(color: Colors.white),
-                ),
+                child: Text(S.of(context).AddDevice),
               ),
             ),
           ),

--- a/lib/widgets/pages/member_details/member_devices_list/member_devices_list_empty.dart
+++ b/lib/widgets/pages/member_details/member_devices_list/member_devices_list_empty.dart
@@ -56,10 +56,7 @@ class MemberDevicesListEmpty extends StatelessWidget {
 
                         onAddDevicePressed(context, selectedMember!.uuid);
                       },
-                      child: Text(
-                        translator.AddDevice,
-                        style: const TextStyle(color: Colors.white),
-                      ),
+                      child: Text(translator.AddDevice),
                     ),
                   );
                 },

--- a/lib/widgets/pages/member_details/member_devices_list/member_devices_list_header.dart
+++ b/lib/widgets/pages/member_details/member_devices_list/member_devices_list_header.dart
@@ -1,24 +1,33 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
-import 'package:weforza/widgets/theme.dart';
 
 class MemberDevicesListHeader extends StatelessWidget {
   const MemberDevicesListHeader({super.key});
 
   @override
   Widget build(BuildContext context) {
-    const theme = AppTheme.memberDevicesList;
-    final child = Text(S.of(context).Devices, style: theme.headerStyle);
+    final title = S.of(context).Devices;
 
     return PlatformAwareWidget(
-      android: (_) => Padding(
-        padding: const EdgeInsets.only(top: 4),
-        child: child,
-      ),
-      ios: (_) => Padding(
+      android: (context) {
+        final textTheme = Theme.of(context).textTheme;
+
+        return Padding(
+          padding: const EdgeInsets.only(top: 4),
+          child: Text(
+            title,
+            style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+          ),
+        );
+      },
+      ios: (context) => Padding(
         padding: const EdgeInsets.only(top: 12),
-        child: child,
+        child: Text(
+          title,
+          style: CupertinoTheme.of(context).textTheme.navTitleTextStyle,
+        ),
       ),
     );
   }

--- a/lib/widgets/pages/member_details/member_devices_list/member_devices_list_item.dart
+++ b/lib/widgets/pages/member_details/member_devices_list/member_devices_list_item.dart
@@ -92,8 +92,8 @@ class _EditDeviceButton extends ConsumerWidget {
         onPressed: () => _onEditDevicePressed(context, ref),
       ),
       ios: (context) => CupertinoIconButton(
-        onPressed: () => _onEditDevicePressed(context, ref),
         icon: CupertinoIcons.pencil,
+        onPressed: () => _onEditDevicePressed(context, ref),
       ),
     );
   }

--- a/lib/widgets/pages/member_details/member_devices_list/member_devices_list_item.dart
+++ b/lib/widgets/pages/member_details/member_devices_list/member_devices_list_item.dart
@@ -7,7 +7,6 @@ import 'package:weforza/widgets/common/device_icon.dart';
 import 'package:weforza/widgets/pages/device_form.dart';
 import 'package:weforza/widgets/platform/cupertino_icon_button.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
-import 'package:weforza/widgets/theme.dart';
 
 class MemberDevicesListItem extends StatelessWidget {
   const MemberDevicesListItem({
@@ -89,10 +88,7 @@ class _EditDeviceButton extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return PlatformAwareWidget(
       android: (context) => IconButton(
-        icon: Icon(
-          Icons.edit,
-          color: AppTheme.memberDevicesList.androidEditDeviceButtonColor,
-        ),
+        icon: Icon(Icons.edit, color: Theme.of(context).primaryColor),
         onPressed: () => _onEditDevicePressed(context, ref),
       ),
       ios: (context) => CupertinoIconButton(

--- a/lib/widgets/pages/member_details/member_name.dart
+++ b/lib/widgets/pages/member_details/member_name.dart
@@ -27,10 +27,7 @@ class MemberName extends ConsumerWidget {
       children: <Widget>[
         Text(
           firstName,
-          style: theme.firstNameStyle.copyWith(
-            fontSize: 25,
-            fontWeight: FontWeight.w500,
-          ),
+          style: theme.firstNameStyle.copyWith(fontSize: 25),
           overflow: TextOverflow.ellipsis,
         ),
         Text(

--- a/lib/widgets/pages/member_list/member_list_item.dart
+++ b/lib/widgets/pages/member_list/member_list_item.dart
@@ -47,7 +47,7 @@ class MemberListItem extends ConsumerWidget {
               ),
             ),
             Expanded(
-              child: MemberNameAndAlias(
+              child: MemberNameAndAlias.twoLines(
                 alias: member.alias,
                 firstLineStyle: theme.firstNameStyle,
                 firstName: member.firstName,

--- a/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
@@ -101,10 +101,7 @@ class BluetoothDisabledError extends StatelessWidget {
         ),
         ios: (_) => CupertinoButton(
           onPressed: onRetry,
-          child: Text(
-            translator.RetryScan,
-            style: const TextStyle(color: CupertinoColors.activeBlue),
-          ),
+          child: Text(translator.RetryScan),
         ),
       ),
     );
@@ -176,10 +173,7 @@ class PermissionDeniedError extends StatelessWidget {
           onPressed: () => Navigator.of(context).pop(),
         ),
         ios: (context) => CupertinoButton(
-          child: Text(
-            translator.GoBack,
-            style: const TextStyle(color: CupertinoColors.activeBlue),
-          ),
+          child: Text(translator.GoBack),
           onPressed: () => Navigator.of(context).pop(),
         ),
       ),

--- a/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
@@ -88,10 +88,7 @@ class BluetoothDisabledError extends StatelessWidget {
         ),
         ios: (_) => CupertinoButton.filled(
           onPressed: () => AppSettings.openBluetoothSettings(),
-          child: Text(
-            translator.GoToSettings,
-            style: const TextStyle(color: Colors.white),
-          ),
+          child: Text(translator.GoToSettings),
         ),
       ),
       secondaryButton: PlatformAwareWidget(
@@ -127,10 +124,7 @@ class GenericScanError extends StatelessWidget {
           onPressed: () => Navigator.of(context).pop(),
         ),
         ios: (context) => CupertinoButton.filled(
-          child: Text(
-            translator.GoBackToDetailPage,
-            style: const TextStyle(color: Colors.white),
-          ),
+          child: Text(translator.GoBackToDetailPage),
           onPressed: () => Navigator.of(context).pop(),
         ),
       ),
@@ -160,10 +154,7 @@ class PermissionDeniedError extends StatelessWidget {
           onPressed: () => AppSettings.openAppSettings(),
         ),
         ios: (_) => CupertinoButton.filled(
-          child: Text(
-            translator.GoToSettings,
-            style: const TextStyle(color: Colors.white),
-          ),
+          child: Text(translator.GoToSettings),
           onPressed: () => AppSettings.openAppSettings(),
         ),
       ),

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_empty.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_empty.dart
@@ -33,10 +33,7 @@ class ManualSelectionListEmpty extends StatelessWidget {
             onPressed: () => Navigator.of(context).pop(),
           ),
           ios: (context) => CupertinoButton.filled(
-            child: Text(
-              translator.GoBack,
-              style: const TextStyle(color: Colors.white),
-            ),
+            child: Text(translator.GoBack),
             onPressed: () => Navigator.of(context).pop(),
           ),
         ),

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_item.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_item.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/model/member.dart';
@@ -29,22 +30,18 @@ class _ManualSelectionListItemState
     extends ConsumerState<ManualSelectionListItem> {
   BoxDecoration? _getDecoration(BuildContext context, bool isSelected) {
     if (isSelected) {
-      RideAttendeeScanResultTheme theme;
+      final theme = Theme.of(context);
 
-      switch (Theme.of(context).platform) {
+      switch (theme.platform) {
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
-          theme = AppTheme.rideAttendeeScanResult.android;
-          break;
+          return BoxDecoration(color: theme.primaryColorDark);
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
-          theme = AppTheme.rideAttendeeScanResult.ios;
-          break;
+          return BoxDecoration(color: CupertinoTheme.of(context).primaryColor);
       }
-
-      return BoxDecoration(color: theme.selectedBackgroundColor);
     }
 
     return null;

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_item.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_item.dart
@@ -61,11 +61,15 @@ class _ManualSelectionListItemState
       isScanned = selectedRideAttendee.isScanned;
     }
 
-    // The text color uses the Theme's default when unselected.
-    final textColor = isSelected ? Colors.white : null;
     const theme = AppTheme.memberListItem;
-    final firstNameStyle = theme.firstNameStyle.copyWith(color: textColor);
-    final lastNameStyle = theme.lastNameStyle.copyWith(color: textColor);
+
+    TextStyle firstNameStyle = theme.firstNameStyle;
+    TextStyle lastNameStyle = theme.lastNameStyle;
+
+    if (isSelected) {
+      firstNameStyle = firstNameStyle.copyWith(color: Colors.white);
+      lastNameStyle = lastNameStyle.copyWith(color: Colors.white);
+    }
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -104,7 +108,7 @@ class _ManualSelectionListItemState
               ),
             ),
             Expanded(
-              child: MemberNameAndAlias(
+              child: MemberNameAndAlias.twoLines(
                 alias: widget.item.alias,
                 firstLineStyle: firstNameStyle,
                 firstName: widget.item.firstName,

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_save_button.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_save_button.dart
@@ -96,10 +96,7 @@ class _SaveButton extends StatelessWidget {
       ios: (_) => CupertinoButton.filled(
         onPressed: onPressed,
         padding: const EdgeInsets.symmetric(horizontal: 24),
-        child: Text(
-          text,
-          style: const TextStyle(fontSize: 16, color: Colors.white),
-        ),
+        child: Text(text),
       ),
     );
   }

--- a/lib/widgets/pages/ride_attendee_scanning_page/scan_button.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/scan_button.dart
@@ -27,10 +27,7 @@ class ScanButton extends StatelessWidget {
           padding: const EdgeInsets.symmetric(vertical: 16),
           child: CupertinoButton.filled(
             onPressed: onPressed,
-            child: Text(
-              text,
-              style: const TextStyle(color: Colors.white),
-            ),
+            child: Text(text),
           ),
         ),
       ),

--- a/lib/widgets/pages/ride_attendee_scanning_page/scan_results_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/scan_results_list.dart
@@ -6,7 +6,6 @@ import 'package:weforza/model/ride_attendee_scanning/scanned_device.dart';
 import 'package:weforza/widgets/common/member_name_and_alias.dart';
 import 'package:weforza/widgets/pages/ride_attendee_scanning_page/scan_button.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
-import 'package:weforza/widgets/theme.dart';
 
 /// This widget represents the scan results list
 /// for the ride attendee scanning page.
@@ -63,7 +62,7 @@ class _ScanResultsListItem extends StatelessWidget {
 
   Widget _buildMultipleOwnersListItem(BuildContext context, int ownersLength) {
     IconData icon;
-    TextStyle style;
+    Color color;
 
     switch (Theme.of(context).platform) {
       case TargetPlatform.android:
@@ -71,16 +70,20 @@ class _ScanResultsListItem extends StatelessWidget {
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         icon = Icons.people;
-        final theme = AppTheme.rideAttendeeScanResult.android;
-        style = theme.multipleOwnersLabelStyle;
+        color = Colors.orange;
         break;
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         icon = CupertinoIcons.person_2_fill;
-        final theme = AppTheme.rideAttendeeScanResult.ios;
-        style = theme.multipleOwnersLabelStyle;
+        color = CupertinoColors.activeOrange;
         break;
     }
+
+    final textStyle = TextStyle(
+      fontStyle: FontStyle.italic,
+      fontSize: 12,
+      color: color,
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -91,7 +94,7 @@ class _ScanResultsListItem extends StatelessWidget {
             children: [
               Padding(
                 padding: const EdgeInsets.only(right: 4),
-                child: Icon(icon, color: style.color),
+                child: Icon(icon, color: textStyle.color),
               ),
               SelectableText(
                 device.name,
@@ -104,7 +107,7 @@ class _ScanResultsListItem extends StatelessWidget {
           padding: const EdgeInsets.only(left: 4),
           child: Text(
             S.of(context).AmountOfRidersWithDeviceName(ownersLength),
-            style: style,
+            style: textStyle,
           ),
         ),
       ],
@@ -112,36 +115,38 @@ class _ScanResultsListItem extends StatelessWidget {
   }
 
   Widget _buildSingleOwnerListItem(BuildContext context) {
-    final owner = device.owners.first;
-    TextStyle textStyle;
-    Widget icon;
+    Color color;
+    IconData icon;
 
-    switch (Theme.of(context).platform) {
+    final theme = Theme.of(context);
+
+    switch (theme.platform) {
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        textStyle = TextStyle(
-          color: AppTheme.rideAttendeeScanResult.android.singleOwnerColor,
-          fontWeight: FontWeight.bold,
-        );
-        icon = Icon(Icons.person, color: textStyle.color);
+        color = theme.primaryColor;
+        icon = Icons.person;
         break;
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
-        textStyle = TextStyle(
-          color: AppTheme.rideAttendeeScanResult.ios.singleOwnerColor,
-          fontWeight: FontWeight.bold,
-        );
-        icon = Icon(CupertinoIcons.person_fill, color: textStyle.color);
+        color = CupertinoTheme.of(context).primaryColor;
+        icon = CupertinoIcons.person_fill;
         break;
     }
+
+    final textStyle = TextStyle(
+      color: color,
+      fontWeight: FontWeight.bold,
+    );
+
+    final owner = device.owners.first;
 
     return Row(
       children: [
         Padding(
           padding: const EdgeInsets.only(right: 4),
-          child: icon,
+          child: Icon(icon, color: textStyle.color),
         ),
         MemberNameAndAlias(
           alias: owner.alias,

--- a/lib/widgets/pages/ride_attendee_scanning_page/scan_results_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/scan_results_list.dart
@@ -148,13 +148,11 @@ class _ScanResultsListItem extends StatelessWidget {
           padding: const EdgeInsets.only(right: 4),
           child: Icon(icon, color: textStyle.color),
         ),
-        MemberNameAndAlias(
+        MemberNameAndAlias.singleLine(
           alias: owner.alias,
-          firstLineStyle: textStyle,
           firstName: owner.firstName,
-          isTwoLine: false,
           lastName: owner.lastName,
-          secondLineStyle: textStyle,
+          style: textStyle,
         ),
       ],
     );

--- a/lib/widgets/pages/ride_attendee_scanning_page/unresolved_owners_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/unresolved_owners_list.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/model/member.dart';
@@ -35,22 +36,22 @@ class _UnresolvedOwnersListState extends State<UnresolvedOwnersList> {
   }
 
   TextStyle _getMultipleOwnersListDescriptionStyle(BuildContext context) {
-    RideAttendeeScanResultTheme theme;
+    Color color;
 
     switch (Theme.of(context).platform) {
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        theme = AppTheme.rideAttendeeScanResult.android;
+        color = Colors.grey;
         break;
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
-        theme = AppTheme.rideAttendeeScanResult.ios;
+        color = CupertinoColors.systemGrey;
         break;
     }
 
-    return theme.multipleOwnersDescriptionStyle;
+    return TextStyle(fontStyle: FontStyle.italic, fontSize: 12, color: color);
   }
 
   @override
@@ -127,22 +128,18 @@ class _UnresolvedOwnersListItem extends StatefulWidget {
 
 class _UnresolvedOwnersListItemState extends State<_UnresolvedOwnersListItem> {
   Color _getSelectedBackgroundColor(BuildContext context) {
-    RideAttendeeScanResultTheme theme;
+    final theme = Theme.of(context);
 
-    switch (Theme.of(context).platform) {
+    switch (theme.platform) {
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        theme = AppTheme.rideAttendeeScanResult.android;
-        break;
+        return theme.primaryColorDark;
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
-        theme = AppTheme.rideAttendeeScanResult.ios;
-        break;
+        return CupertinoTheme.of(context).primaryColor;
     }
-
-    return theme.selectedBackgroundColor;
   }
 
   @override

--- a/lib/widgets/pages/ride_attendee_scanning_page/unresolved_owners_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/unresolved_owners_list.dart
@@ -160,7 +160,7 @@ class _UnresolvedOwnersListItemState extends State<_UnresolvedOwnersListItem> {
 
     Widget child = Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      child: MemberNameAndAlias(
+      child: MemberNameAndAlias.twoLines(
         alias: widget.item.alias,
         firstLineStyle: firstNameStyle,
         firstName: widget.item.firstName,

--- a/lib/widgets/pages/ride_details/ride_details_attendees/ride_details_attendees_list_item.dart
+++ b/lib/widgets/pages/ride_details/ride_details_attendees/ride_details_attendees_list_item.dart
@@ -16,18 +16,13 @@ class RideDetailsAttendeesListItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const theme = AppTheme.memberListItem;
-    final style = theme.lastNameStyle;
-
     return Padding(
       padding: const EdgeInsets.all(4),
-      child: MemberNameAndAlias(
-        firstLineStyle: style,
-        secondLineStyle: style,
+      child: MemberNameAndAlias.singleLine(
         firstName: firstName,
         lastName: lastName,
         alias: alias,
-        isTwoLine: false,
+        style: AppTheme.memberListItem.lastNameStyle,
       ),
     );
   }

--- a/lib/widgets/pages/ride_details/ride_details_page.dart
+++ b/lib/widgets/pages/ride_details/ride_details_page.dart
@@ -15,7 +15,6 @@ import 'package:weforza/widgets/pages/ride_details/ride_details_attendees/ride_d
 import 'package:weforza/widgets/pages/ride_details/ride_details_title.dart';
 import 'package:weforza/widgets/platform/cupertino_icon_button.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
-import 'package:weforza/widgets/theme.dart';
 
 class RideDetailsPage extends ConsumerStatefulWidget {
   const RideDetailsPage({super.key});
@@ -61,7 +60,7 @@ class RideDetailsPageState extends ConsumerState<RideDetailsPage> {
   Widget _buildAndroidLayout(BuildContext context) {
     final translator = S.of(context);
 
-    final style = AppTheme.desctructiveAction.androidDefaultErrorStyle;
+    final errorColor = Theme.of(context).errorColor;
 
     return Scaffold(
       appBar: AppBar(
@@ -85,8 +84,11 @@ class RideDetailsPageState extends ConsumerState<RideDetailsPage> {
               PopupMenuItem<RideDetailsPageOptions>(
                 value: RideDetailsPageOptions.delete,
                 child: ListTile(
-                  leading: Icon(Icons.delete, color: style.color),
-                  title: Text(translator.Delete, style: style),
+                  leading: Icon(Icons.delete, color: errorColor),
+                  title: Text(
+                    translator.Delete,
+                    style: TextStyle(color: errorColor),
+                  ),
                 ),
               ),
             ],

--- a/lib/widgets/pages/ride_list/ride_list_item.dart
+++ b/lib/widgets/pages/ride_list/ride_list_item.dart
@@ -15,15 +15,17 @@ class RideListItem extends ConsumerWidget {
 
   Color? _getMonthColor(BuildContext context) {
     if (ride.date.month % 2 == 0) {
-      switch (Theme.of(context).platform) {
+      final theme = Theme.of(context);
+
+      switch (theme.platform) {
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
-          return Colors.blue;
+          return theme.primaryColor;
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
-          return CupertinoColors.activeBlue;
+          return CupertinoTheme.of(context).primaryColor;
       }
     }
 

--- a/lib/widgets/pages/ride_list/ride_list_page.dart
+++ b/lib/widgets/pages/ride_list/ride_list_page.dart
@@ -60,10 +60,10 @@ class RideListPage extends StatelessWidget {
               ),
             ),
             CupertinoIconButton(
+              icon: CupertinoIcons.arrow_up_doc_fill,
               onPressed: () => Navigator.of(context).push(
                 MaterialPageRoute(builder: (_) => const ExportRidePage()),
               ),
-              icon: CupertinoIcons.arrow_up_doc_fill,
             ),
           ],
         ),

--- a/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
@@ -93,13 +93,13 @@ class _AddExcludedTermSuffixIcon extends StatelessWidget {
         }
 
         return PlatformAwareWidget(
-          android: (_) => IconButton(
-            color: Colors.blue,
+          android: (context) => IconButton(
+            color: Theme.of(context).primaryColor,
             icon: const Icon(Icons.check),
             onPressed: onTap,
           ),
-          ios: (_) => CupertinoIconButton(
-            color: CupertinoColors.activeBlue,
+          ios: (context) => CupertinoIconButton(
+            color: CupertinoTheme.of(context).primaryColor,
             icon: CupertinoIcons.checkmark_alt,
             onPressed: onTap,
           ),

--- a/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
@@ -99,7 +99,6 @@ class _AddExcludedTermSuffixIcon extends StatelessWidget {
             onPressed: onTap,
           ),
           ios: (context) => CupertinoIconButton(
-            color: CupertinoTheme.of(context).primaryColor,
             icon: CupertinoIcons.checkmark_alt,
             onPressed: onTap,
           ),

--- a/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field_button_bar.dart
+++ b/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field_button_bar.dart
@@ -63,13 +63,13 @@ class EditExcludedTermInputFieldButtonBar extends StatelessWidget {
         final isValid = validator(context, currentValue) == null;
 
         final confirmButton = PlatformAwareWidget(
-          android: (_) => IconButton(
-            color: Colors.blue,
+          android: (context) => IconButton(
+            color: Theme.of(context).primaryColor,
             icon: const Icon(Icons.check),
             onPressed: isValid ? () => onCommitValidTerm(currentValue) : null,
           ),
-          ios: (_) => CupertinoIconButton(
-            color: CupertinoColors.activeBlue,
+          ios: (context) => CupertinoIconButton(
+            color: CupertinoTheme.of(context).primaryColor,
             icon: CupertinoIcons.checkmark_alt,
             onPressed: isValid ? () => onCommitValidTerm(currentValue) : null,
           ),

--- a/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field_button_bar.dart
+++ b/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field_button_bar.dart
@@ -69,7 +69,6 @@ class EditExcludedTermInputFieldButtonBar extends StatelessWidget {
             onPressed: isValid ? () => onCommitValidTerm(currentValue) : null,
           ),
           ios: (context) => CupertinoIconButton(
-            color: CupertinoTheme.of(context).primaryColor,
             icon: CupertinoIcons.checkmark_alt,
             onPressed: isValid ? () => onCommitValidTerm(currentValue) : null,
           ),

--- a/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field_button_bar.dart
+++ b/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field_button_bar.dart
@@ -2,7 +2,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:weforza/widgets/platform/cupertino_icon_button.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
-import 'package:weforza/widgets/theme.dart';
 
 /// This widget represents the button bar for an [EditExcludedTermInputField].
 ///
@@ -48,10 +47,7 @@ class EditExcludedTermInputFieldButtonBar extends StatelessWidget {
       // The delete button is always shown.
       child: PlatformAwareWidget(
         android: (context) => IconButton(
-          icon: Icon(
-            Icons.delete,
-            color: AppTheme.desctructiveAction.androidDefaultErrorStyle.color,
-          ),
+          icon: Icon(Icons.delete, color: Theme.of(context).errorColor),
           onPressed: () => onDeletePressed(context),
           padding: EdgeInsets.zero,
         ),

--- a/lib/widgets/pages/settings/member_list_filter.dart
+++ b/lib/widgets/pages/settings/member_list_filter.dart
@@ -18,6 +18,22 @@ class MemberListFilter extends StatelessWidget {
 
   final Stream<MemberFilterOption> stream;
 
+  Widget _buildChip({
+    required MemberFilterOption groupValue,
+    required Widget label,
+    required MemberFilterOption value,
+  }) {
+    return ChoiceChip(
+      label: label,
+      selected: groupValue == value,
+      onSelected: (selected) {
+        if (selected) {
+          onChanged(value);
+        }
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final translator = S.of(context);
@@ -31,35 +47,23 @@ class MemberListFilter extends StatelessWidget {
         return PlatformAwareWidget(
           android: (_) => Row(
             children: [
-              ChoiceChip(
+              _buildChip(
+                groupValue: currentFilter,
                 label: Text(translator.All),
-                selected: currentFilter == MemberFilterOption.all,
-                onSelected: (selected) {
-                  if (selected) {
-                    onChanged(MemberFilterOption.all);
-                  }
-                },
+                value: MemberFilterOption.all,
               ),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 8),
-                child: ChoiceChip(
+                child: _buildChip(
+                  groupValue: currentFilter,
                   label: Text(translator.Active),
-                  selected: currentFilter == MemberFilterOption.active,
-                  onSelected: (selected) {
-                    if (selected) {
-                      onChanged(MemberFilterOption.active);
-                    }
-                  },
+                  value: MemberFilterOption.active,
                 ),
               ),
-              ChoiceChip(
+              _buildChip(
+                groupValue: currentFilter,
                 label: Text(translator.Inactive),
-                selected: currentFilter == MemberFilterOption.inactive,
-                onSelected: (selected) {
-                  if (selected) {
-                    onChanged(MemberFilterOption.inactive);
-                  }
-                },
+                value: MemberFilterOption.inactive,
               ),
             ],
           ),

--- a/lib/widgets/pages/settings/reset_ride_calendar_button.dart
+++ b/lib/widgets/pages/settings/reset_ride_calendar_button.dart
@@ -20,11 +20,15 @@ class ResetRideCalendarButton extends ConsumerWidget {
 
   Widget _buildButton(BuildContext context, {bool enabled = true}) {
     return PlatformAwareWidget(
-      android: (context) => ElevatedButton(
-        style: AppTheme.desctructiveAction.elevatedButtonTheme,
-        onPressed: enabled ? () => _showResetCalendarDialog(context) : null,
-        child: Text(S.of(context).ResetRideCalendar),
-      ),
+      android: (context) {
+        final styles = Theme.of(context).extension<DestructiveButtons>()!;
+
+        return ElevatedButton(
+          style: styles.elevatedButtonStyle,
+          onPressed: enabled ? () => _showResetCalendarDialog(context) : null,
+          child: Text(S.of(context).ResetRideCalendar),
+        );
+      },
       ios: (context) => CupertinoButton(
         borderRadius: BorderRadius.zero,
         padding: EdgeInsets.zero,

--- a/lib/widgets/pages/settings/settings_page.dart
+++ b/lib/widgets/pages/settings/settings_page.dart
@@ -99,7 +99,8 @@ class SettingsPageState extends ConsumerState<SettingsPage>
 
   Widget _buildAndroidWidget(BuildContext context) {
     final translator = S.of(context);
-    final textTheme = Theme.of(context).textTheme;
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
 
     return Scaffold(
       appBar: AppBar(
@@ -139,10 +140,14 @@ class SettingsPageState extends ConsumerState<SettingsPage>
                 translator.RiderListFilter,
                 style: textTheme.titleMedium,
               ),
-              MemberListFilter(
-                initialFilter: memberFilterController.value,
-                onChanged: memberFilterController.add,
-                stream: memberFilterController,
+              Theme(
+                // TODO: remove when useMaterial3 is true in MaterialApp
+                data: ThemeData(useMaterial3: true, chipTheme: theme.chipTheme),
+                child: MemberListFilter(
+                  initialFilter: memberFilterController.value,
+                  onChanged: memberFilterController.add,
+                  stream: memberFilterController,
+                ),
               ),
               Text(
                 translator.RiderListFilterDescription,

--- a/lib/widgets/platform/cupertino_icon_button.dart
+++ b/lib/widgets/platform/cupertino_icon_button.dart
@@ -4,7 +4,7 @@ import 'package:flutter/cupertino.dart';
 class CupertinoIconButton extends StatelessWidget {
   const CupertinoIconButton({
     super.key,
-    this.color = CupertinoColors.activeBlue,
+    this.color,
     required this.icon,
     required this.onPressed,
     this.size = kMinInteractiveDimensionCupertino,
@@ -12,8 +12,8 @@ class CupertinoIconButton extends StatelessWidget {
 
   /// The color for the icon.
   ///
-  /// Defaults to [CupertinoColors.activeBlue].
-  final Color color;
+  /// Defaults to [CupertinoThemeData.primaryColor] if null.
+  final Color? color;
 
   /// The icon for the button.
   final IconData icon;
@@ -35,7 +35,9 @@ class CupertinoIconButton extends StatelessWidget {
       padding: EdgeInsets.zero,
       child: Icon(
         icon,
-        color: onPressed == null ? CupertinoColors.placeholderText : color,
+        color: onPressed == null
+            ? CupertinoColors.placeholderText
+            : color ?? CupertinoTheme.of(context).primaryColor,
       ),
     );
   }

--- a/lib/widgets/platform/platform_aware_icon.dart
+++ b/lib/widgets/platform/platform_aware_icon.dart
@@ -6,27 +6,27 @@ import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 class PlatformAwareIcon extends StatelessWidget {
   const PlatformAwareIcon({
     super.key,
-    this.androidColor = Colors.blue,
+    this.androidColor,
     required this.androidIcon,
-    this.iosColor = CupertinoColors.activeBlue,
+    this.iosColor,
     required this.iosIcon,
     this.size,
   });
 
   /// The color for the [androidIcon].
   ///
-  /// Defaults to [Colors.blue].
-  final Color androidColor;
+  /// Defaults to [ThemeData.primaryColor] if this is null.
+  final Color? androidColor;
 
   /// The icon for Android.
   final IconData androidIcon;
 
   /// The color for the [iosIcon].
-  final Color iosColor;
+  ///
+  /// Defaults to [CupertinoThemeData.primaryColor] if this is null.
+  final Color? iosColor;
 
   /// The icon for iOS.
-  ///
-  /// Defaults to [CupertinoColors.activeBlue].
   final IconData iosIcon;
 
   /// The size for the icon.
@@ -35,8 +35,16 @@ class PlatformAwareIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: (_) => Icon(androidIcon, color: androidColor, size: size),
-      ios: (_) => Icon(iosIcon, color: iosColor, size: size),
+      android: (context) => Icon(
+        androidIcon,
+        color: androidColor ?? Theme.of(context).primaryColor,
+        size: size,
+      ),
+      ios: (context) => Icon(
+        iosIcon,
+        color: iosColor ?? CupertinoTheme.of(context).primaryColor,
+        size: size,
+      ),
     );
   }
 }

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -39,7 +39,7 @@ abstract class AppTheme {
         ),
       ),
     ),
-    colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+    colorScheme: colorScheme,
   );
 
   /// The color scheme for the MaterialApp.

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -56,9 +56,6 @@ abstract class AppTheme {
   /// The theme for the bottom bar on the manual selection.
   static const manualSelectionBottomBar = ManualSelectionBottomBarTheme();
 
-  /// The member devices list theme.
-  static const memberDevicesList = MemberDeviceListTheme();
-
   /// The member list item theme.
   static const memberListItem = MemberListItemTheme();
 
@@ -116,21 +113,6 @@ class ManualSelectionBottomBarTheme {
 
   /// The active track color for the filter switch.
   final Color switchActiveTrackColor = const Color(0xFF81D4FA);
-}
-
-/// This class represents the theme for the member devices list.
-class MemberDeviceListTheme {
-  const MemberDeviceListTheme();
-
-  /// The color for the edit device button on Android.
-  /// iOS uses a [CupertinoColors] value to resolve a color.
-  final Color androidEditDeviceButtonColor = const Color(0xFF64B5F6);
-
-  /// The text style for the member devices list header.
-  final TextStyle headerStyle = const TextStyle(
-    fontWeight: FontWeight.bold,
-    fontSize: 20,
-  );
 }
 
 /// This class defines the theme for member list items.

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -9,9 +9,11 @@ abstract class AppTheme {
     appBarTheme: const AppBarTheme(
       systemOverlayStyle: SystemUiOverlayStyle.light,
     ),
-    chipTheme: const ChipThemeData(
-      selectedColor: Colors.blue,
-      secondaryLabelStyle: TextStyle(color: Colors.white),
+    chipTheme: ChipThemeData(
+      checkmarkColor: Colors.white,
+      selectedColor: colorScheme.primary,
+      secondaryLabelStyle: const TextStyle(color: Colors.white),
+      side: BorderSide(color: colorScheme.primary),
     ),
     extensions: <ThemeExtension>[
       DestructiveButtons(errorColor: colorScheme.error),

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -45,9 +45,6 @@ abstract class AppTheme {
   /// The color scheme for the MaterialApp.
   static final colorScheme = ColorScheme.fromSeed(seedColor: Colors.blue);
 
-  /// The device type picker theme.
-  static final deviceTypePicker = DeviceTypePickerThemes();
-
   /// The [CupertinoThemeData] for the [CupertinoApp].
   static const iosTheme = CupertinoThemeData(
     primaryColor: CupertinoColors.activeBlue,
@@ -67,37 +64,6 @@ abstract class AppTheme {
 
   /// The theme for the scan stepper.
   static const scanStepper = ScanStepperThemes();
-}
-
-/// This class represents the data for [DeviceTypePickerThemes].
-class DeviceTypePickerTheme {
-  const DeviceTypePickerTheme({
-    required this.selectedColor,
-    required this.unselectedColor,
-  });
-
-  /// The color for a selected device type.
-  final Color selectedColor;
-
-  /// The color for an unselected device type.
-  final Color unselectedColor;
-}
-
-/// This class represents the theme for the device type picker.
-class DeviceTypePickerThemes {
-  DeviceTypePickerThemes();
-
-  /// The device type picker theme for Android.
-  final android = DeviceTypePickerTheme(
-    selectedColor: Colors.blue,
-    unselectedColor: Colors.blue.shade100,
-  );
-
-  /// The device type picker theme for iOS.
-  final ios = const DeviceTypePickerTheme(
-    selectedColor: CupertinoColors.activeBlue,
-    unselectedColor: CupertinoColors.systemGrey4,
-  );
 }
 
 /// This class represents the theme for the bottom bar

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -57,9 +57,6 @@ abstract class AppTheme {
   /// The member list item theme.
   static const memberListItem = MemberListItemTheme();
 
-  /// The profile image placeholder theme.
-  static const profileImagePlaceholder = ProfileImagePlaceholderTheme();
-
   /// The ride attendee scan results theme.
   static const rideAttendeeScanResult = RideAttendeeScanResultThemes();
 
@@ -166,23 +163,6 @@ class MemberListItemTheme {
 
   /// The text style for the last name.
   final TextStyle lastNameStyle = const TextStyle(fontSize: 14);
-}
-
-/// This class represents the theme for the profile image placeholder.
-class ProfileImagePlaceholderTheme {
-  const ProfileImagePlaceholderTheme();
-
-  /// The background color for the profile image placeholder.
-  final Color backgroundColor = const Color(0xFF1976D2);
-
-  /// The icon color for the profile image placeholder.
-  final Color iconColor = Colors.white;
-
-  /// The text style for the displayed initials.
-  final TextStyle initialsStyle = const TextStyle(
-    fontFamily: 'Roboto',
-    color: Colors.white,
-  );
 }
 
 /// This class represents the theme for the ride calendar date picker.

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -13,6 +13,9 @@ abstract class AppTheme {
       selectedColor: Colors.blue,
       secondaryLabelStyle: TextStyle(color: Colors.white),
     ),
+    extensions: <ThemeExtension>[
+      DestructiveButtons(errorColor: colorScheme.error),
+    ],
     textButtonTheme: TextButtonThemeData(
       style: TextButton.styleFrom(
         foregroundColor: Colors.blue,
@@ -37,8 +40,8 @@ abstract class AppTheme {
     colorScheme: ColorScheme.fromSwatch(primarySwatch: Colors.blue),
   );
 
-  /// The theme for destructive actions, such as delete buttons.
-  static final desctructiveAction = DestructiveActionTheme();
+  /// The color scheme for the MaterialApp.
+  static final colorScheme = ColorScheme.fromSeed(seedColor: Colors.blue);
 
   /// The device type picker theme.
   static final deviceTypePicker = DeviceTypePickerThemes();
@@ -65,26 +68,6 @@ abstract class AppTheme {
 
   /// The theme for the scan stepper.
   static const scanStepper = ScanStepperThemes();
-}
-
-/// This class represents the theme for destructive action buttons.
-class DestructiveActionTheme {
-  /// The default text style for Android error messages.
-  final androidDefaultErrorStyle = const TextStyle(color: Colors.red);
-
-  /// The medium text style for Android error messages.
-  final androidMediumErrorStyle = const TextStyle(
-    fontSize: 16,
-    color: Colors.red,
-  );
-
-  /// The theme for destructive [ElevatedButton]s.
-  final elevatedButtonTheme = ElevatedButton.styleFrom(
-    backgroundColor: Colors.red,
-  );
-
-  /// The theme for destructive [TextButton]s.
-  final textButtonTheme = TextButton.styleFrom(foregroundColor: Colors.red);
 }
 
 /// This class represents the data for [DeviceTypePickerThemes].
@@ -254,4 +237,43 @@ class ScanStepperThemes {
     ),
     inactive: CupertinoColors.inactiveGray,
   );
+}
+
+/// This class defines a theme extension for destructive Material buttons.
+@immutable
+class DestructiveButtons extends ThemeExtension<DestructiveButtons> {
+  DestructiveButtons({
+    this.errorColor,
+  })  : elevatedButtonStyle = ElevatedButton.styleFrom(
+          backgroundColor: errorColor,
+        ),
+        textButtonStyle = TextButton.styleFrom(foregroundColor: errorColor);
+
+  /// The style for destructive [ElevatedButton]s.
+  final ButtonStyle elevatedButtonStyle;
+
+  /// The color that is used to create the [ButtonStyle]s.
+  final Color? errorColor;
+
+  /// The style for destructive [TextButton]s.
+  final ButtonStyle textButtonStyle;
+
+  @override
+  DestructiveButtons copyWith({Color? errorColor}) {
+    return DestructiveButtons(errorColor: errorColor);
+  }
+
+  @override
+  ThemeExtension<DestructiveButtons> lerp(
+    ThemeExtension<DestructiveButtons>? other,
+    double t,
+  ) {
+    if (other is! DestructiveButtons) {
+      return this;
+    }
+
+    return DestructiveButtons(
+      errorColor: Color.lerp(errorColor, other.errorColor, t),
+    );
+  }
 }

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -57,9 +57,6 @@ abstract class AppTheme {
   /// The member list item theme.
   static const memberListItem = MemberListItemTheme();
 
-  /// The ride attendee scan results theme.
-  static const rideAttendeeScanResult = RideAttendeeScanResultThemes();
-
   /// The ride calendar theme.
   static const rideCalendar = RideCalendarTheme();
 
@@ -256,64 +253,5 @@ class ScanStepperThemes {
       color: CupertinoColors.activeBlue,
     ),
     inactive: CupertinoColors.inactiveGray,
-  );
-}
-
-/// This class represents the data for a [RideAttendeeScanResultThemes] sub theme.
-class RideAttendeeScanResultTheme {
-  const RideAttendeeScanResultTheme({
-    required this.multipleOwnersDescriptionStyle,
-    required this.multipleOwnersLabelStyle,
-    required this.selectedBackgroundColor,
-    required this.singleOwnerColor,
-  });
-
-  /// The style for the multiple owners description label.
-  final TextStyle multipleOwnersDescriptionStyle;
-
-  /// The style for the multiple owners label.
-  final TextStyle multipleOwnersLabelStyle;
-
-  /// The background color for a selected item.
-  final Color selectedBackgroundColor;
-
-  /// The color for a scan result that has a single owner.
-  final Color singleOwnerColor;
-}
-
-/// This class represents the theme for ride attendee scan results.
-class RideAttendeeScanResultThemes {
-  const RideAttendeeScanResultThemes();
-
-  /// The scan result theme for Android.
-  final android = const RideAttendeeScanResultTheme(
-    multipleOwnersDescriptionStyle: TextStyle(
-      fontStyle: FontStyle.italic,
-      fontSize: 12,
-      color: Colors.grey,
-    ),
-    multipleOwnersLabelStyle: TextStyle(
-      fontStyle: FontStyle.italic,
-      fontSize: 12,
-      color: Colors.orange,
-    ),
-    selectedBackgroundColor: Color(0xFF1976D2),
-    singleOwnerColor: Colors.blue,
-  );
-
-  /// The scan result theme for iOS.
-  final ios = const RideAttendeeScanResultTheme(
-    multipleOwnersDescriptionStyle: TextStyle(
-      fontStyle: FontStyle.italic,
-      fontSize: 12,
-      color: CupertinoColors.systemGrey,
-    ),
-    multipleOwnersLabelStyle: TextStyle(
-      fontStyle: FontStyle.italic,
-      fontSize: 12,
-      color: CupertinoColors.activeOrange,
-    ),
-    selectedBackgroundColor: CupertinoColors.activeBlue,
-    singleOwnerColor: CupertinoColors.activeBlue,
   );
 }

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -39,7 +39,7 @@ abstract class AppTheme {
         ),
       ),
     ),
-    colorScheme: ColorScheme.fromSwatch(primarySwatch: Colors.blue),
+    colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
   );
 
   /// The color scheme for the MaterialApp.


### PR DESCRIPTION
This PR migrates the application to use `ColorScheme.fromSeed()`. Using a seed enables the use of the Material 3 color schemes in the application which is required for #170 .

Fixes #207 