### PR TITLE
Platform aware icon primary color refactor

### DIFF
--- a/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
@@ -93,13 +93,13 @@ class _AddExcludedTermSuffixIcon extends StatelessWidget {
         }
 
         return PlatformAwareWidget(
-          android: (_) => IconButton(
-            color: Colors.blue,
+          android: (context) => IconButton(
+            color: Theme.of(context).primaryColor,
             icon: const Icon(Icons.check),
             onPressed: onTap,
           ),
-          ios: (_) => CupertinoIconButton(
-            color: CupertinoColors.activeBlue,
+          ios: (context) => CupertinoIconButton(
+            color: CupertinoTheme.of(context).primaryColor,
             icon: CupertinoIcons.checkmark_alt,
             onPressed: onTap,
           ),

--- a/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field_button_bar.dart
+++ b/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field_button_bar.dart
@@ -63,13 +63,13 @@ class EditExcludedTermInputFieldButtonBar extends StatelessWidget {
         final isValid = validator(context, currentValue) == null;
 
         final confirmButton = PlatformAwareWidget(
-          android: (_) => IconButton(
-            color: Colors.blue,
+          android: (context) => IconButton(
+            color: Theme.of(context).primaryColor,
             icon: const Icon(Icons.check),
             onPressed: isValid ? () => onCommitValidTerm(currentValue) : null,
           ),
-          ios: (_) => CupertinoIconButton(
-            color: CupertinoColors.activeBlue,
+          ios: (context) => CupertinoIconButton(
+            color: CupertinoTheme.of(context).primaryColor,
             icon: CupertinoIcons.checkmark_alt,
             onPressed: isValid ? () => onCommitValidTerm(currentValue) : null,
           ),

--- a/lib/widgets/platform/platform_aware_icon.dart
+++ b/lib/widgets/platform/platform_aware_icon.dart
@@ -6,27 +6,27 @@ import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 class PlatformAwareIcon extends StatelessWidget {
   const PlatformAwareIcon({
     super.key,
-    this.androidColor = Colors.blue,
+    this.androidColor,
     required this.androidIcon,
-    this.iosColor = CupertinoColors.activeBlue,
+    this.iosColor,
     required this.iosIcon,
     this.size,
   });
 
   /// The color for the [androidIcon].
   ///
-  /// Defaults to [Colors.blue].
-  final Color androidColor;
+  /// Defaults to [ThemeData.primaryColor] if this is null.
+  final Color? androidColor;
 
   /// The icon for Android.
   final IconData androidIcon;
 
   /// The color for the [iosIcon].
-  final Color iosColor;
+  ///
+  /// Defaults to [CupertinoThemeData.primaryColor] if this is null.
+  final Color? iosColor;
 
   /// The icon for iOS.
-  ///
-  /// Defaults to [CupertinoColors.activeBlue].
   final IconData iosIcon;
 
   /// The size for the icon.
@@ -35,8 +35,16 @@ class PlatformAwareIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: (_) => Icon(androidIcon, color: androidColor, size: size),
-      ios: (_) => Icon(iosIcon, color: iosColor, size: size),
+      android: (context) => Icon(
+        androidIcon,
+        color: androidColor ?? Theme.of(context).primaryColor,
+        size: size,
+      ),
+      ios: (context) => Icon(
+        iosIcon,
+        color: iosColor ?? CupertinoTheme.of(context).primaryColor,
+        size: size,
+      ),
     );
   }
 }


### PR DESCRIPTION
This PR refactors `PlatformAwareIcon` to use the theme's primary color as default color.
It also makes the confirm button in the excluded term text fields use the theme's primary color