### PR TITLE
Refactor member list item theme into a rider text theme class

### DIFF
--- a/lib/widgets/pages/member_details/member_name.dart
+++ b/lib/widgets/pages/member_details/member_name.dart
@@ -20,28 +20,25 @@ class MemberName extends ConsumerWidget {
       selectedMemberProvider.select((value) => value!.alias),
     );
 
-    const theme = AppTheme.memberListItem;
+    const textTheme = AppTheme.riderTextTheme;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
         Text(
           firstName,
-          style: theme.firstNameStyle.copyWith(fontSize: 25),
+          style: textTheme.firstNameLargeStyle,
           overflow: TextOverflow.ellipsis,
         ),
         Text(
           lastName,
-          style: theme.lastNameStyle.copyWith(fontSize: 20),
+          style: textTheme.lastNameLargeStyle,
           overflow: TextOverflow.ellipsis,
         ),
         if (alias.isNotEmpty)
           Text(
             "'$alias'",
-            style: theme.lastNameStyle.copyWith(
-              fontSize: 15,
-              fontStyle: FontStyle.italic,
-            ),
+            style: textTheme.aliasStyle,
             overflow: TextOverflow.ellipsis,
           ),
       ],

--- a/lib/widgets/pages/member_list/member_list_item.dart
+++ b/lib/widgets/pages/member_list/member_list_item.dart
@@ -24,7 +24,7 @@ class MemberListItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    const theme = AppTheme.memberListItem;
+    const textTheme = AppTheme.riderTextTheme;
 
     return GestureDetector(
       onTap: () {
@@ -49,10 +49,10 @@ class MemberListItem extends ConsumerWidget {
             Expanded(
               child: MemberNameAndAlias.twoLines(
                 alias: member.alias,
-                firstLineStyle: theme.firstNameStyle,
+                firstLineStyle: textTheme.firstNameStyle,
                 firstName: member.firstName,
                 lastName: member.lastName,
-                secondLineStyle: theme.lastNameStyle,
+                secondLineStyle: textTheme.lastNameStyle,
               ),
             ),
             Padding(

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_item.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_item.dart
@@ -61,10 +61,10 @@ class _ManualSelectionListItemState
       isScanned = selectedRideAttendee.isScanned;
     }
 
-    const theme = AppTheme.memberListItem;
+    const textTheme = AppTheme.riderTextTheme;
 
-    TextStyle firstNameStyle = theme.firstNameStyle;
-    TextStyle lastNameStyle = theme.lastNameStyle;
+    TextStyle firstNameStyle = textTheme.firstNameStyle;
+    TextStyle lastNameStyle = textTheme.lastNameStyle;
 
     if (isSelected) {
       firstNameStyle = firstNameStyle.copyWith(color: Colors.white);

--- a/lib/widgets/pages/ride_attendee_scanning_page/unresolved_owners_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/unresolved_owners_list.dart
@@ -148,10 +148,10 @@ class _UnresolvedOwnersListItemState extends State<_UnresolvedOwnersListItem> {
       widget.item.uuid,
     );
 
-    const theme = AppTheme.memberListItem;
+    const textTheme = AppTheme.riderTextTheme;
 
-    TextStyle firstNameStyle = theme.firstNameStyle;
-    TextStyle lastNameStyle = theme.lastNameStyle;
+    TextStyle firstNameStyle = textTheme.firstNameStyle;
+    TextStyle lastNameStyle = textTheme.lastNameStyle;
 
     if (selectedAttendee != null) {
       firstNameStyle = firstNameStyle.copyWith(color: Colors.white);

--- a/lib/widgets/pages/ride_details/ride_details_attendees/ride_details_attendees_list_item.dart
+++ b/lib/widgets/pages/ride_details/ride_details_attendees/ride_details_attendees_list_item.dart
@@ -22,7 +22,7 @@ class RideDetailsAttendeesListItem extends StatelessWidget {
         firstName: firstName,
         lastName: lastName,
         alias: alias,
-        style: AppTheme.memberListItem.lastNameStyle,
+        style: AppTheme.riderTextTheme.lastNameStyle,
       ),
     );
   }

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -53,11 +53,11 @@ abstract class AppTheme {
   /// The theme for the bottom bar on the manual selection.
   static const manualSelectionBottomBar = ManualSelectionBottomBarTheme();
 
-  /// The member list item theme.
-  static const memberListItem = MemberListItemTheme();
-
   /// The ride calendar theme.
   static const rideCalendar = RideCalendarTheme();
+
+  /// The text theme for rider names.
+  static const riderTextTheme = RiderTextTheme();
 
   /// The theme for the scan stepper.
   static const scanStepper = ScanStepperThemes();
@@ -76,20 +76,6 @@ class ManualSelectionBottomBarTheme {
 
   /// The active track color for the filter switch.
   final Color switchActiveTrackColor = const Color(0xFF81D4FA);
-}
-
-/// This class defines the theme for member list items.
-class MemberListItemTheme {
-  const MemberListItemTheme();
-
-  /// The text style for the first name.
-  final TextStyle firstNameStyle = const TextStyle(
-    fontSize: 18,
-    fontWeight: FontWeight.w500,
-  );
-
-  /// The text style for the last name.
-  final TextStyle lastNameStyle = const TextStyle(fontSize: 14);
 }
 
 /// This class represents the theme for the ride calendar date picker.
@@ -112,6 +98,36 @@ class RideCalendarTheme {
 
   /// The color for a day that is currently selected.
   final Color selectedDay = const Color(0xFF90CAF9);
+}
+
+/// This class defines the text theme for rider names.
+@immutable
+class RiderTextTheme {
+  const RiderTextTheme();
+
+  /// The text style for rider aliases.
+  final TextStyle aliasStyle = const TextStyle(
+    fontSize: 14,
+    fontStyle: FontStyle.italic,
+  );
+
+  /// The style for rider first names, slightly larger than [firstNameStyle].
+  final TextStyle firstNameLargeStyle = const TextStyle(
+    fontSize: 24,
+    fontWeight: FontWeight.w500,
+  );
+
+  /// The style for rider first names.
+  final TextStyle firstNameStyle = const TextStyle(
+    fontSize: 18,
+    fontWeight: FontWeight.w500,
+  );
+
+  /// The style for rider last names, slightly larger than [lastNameStyle].
+  final TextStyle lastNameLargeStyle = const TextStyle(fontSize: 20);
+
+  /// The style for rider last names.
+  final TextStyle lastNameStyle = const TextStyle(fontSize: 14);
 }
 
 /// This class represents the data for a [ScanStepperTheme] sub theme.


### PR DESCRIPTION
This PR refactors the member list theme so that `copyWith()` is no longer needed