### PR TITLE
Inline the scheduled day style

### DIFF
--- a/lib/widgets/custom/add_ride_calendar/add_ride_calendar_item.dart
+++ b/lib/widgets/custom/add_ride_calendar/add_ride_calendar_item.dart
@@ -57,10 +57,9 @@ class AddRideCalendarItem extends StatelessWidget {
       initialData: delegate.currentSelection,
       stream: delegate.selection,
       builder: (context, _) {
-        const theme = AppTheme.rideCalendar;
         final backgroundColor = _computeBackgroundColor();
         final style = delegate.isBeforeToday(date) || delegate.isScheduled(date)
-            ? theme.scheduledDayStyle
+            ? const TextStyle(color: Colors.white)
             : null;
 
         return GestureDetector(

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -130,11 +130,6 @@ class RideCalendarTheme {
   /// The color for a day that is in the past, which had a ride scheduled.
   final Color pastRide = const Color(0xFF616161);
 
-  /// The text style for a day that has a ride scheduled,
-  /// regardless if this day is in the past, in the future
-  /// or in the current selection of days.
-  final TextStyle scheduledDayStyle = const TextStyle(color: Colors.white);
-
   /// The color for a day that is currently selected.
   final Color selectedDay = const Color(0xFF90CAF9);
 }

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -63,6 +63,45 @@ abstract class AppTheme {
   static const scanStepper = ScanStepperThemes();
 }
 
+/// This class defines a theme extension for destructive Material buttons.
+@immutable
+class DestructiveButtons extends ThemeExtension<DestructiveButtons> {
+  DestructiveButtons({
+    this.errorColor,
+  })  : elevatedButtonStyle = ElevatedButton.styleFrom(
+          backgroundColor: errorColor,
+        ),
+        textButtonStyle = TextButton.styleFrom(foregroundColor: errorColor);
+
+  /// The style for destructive [ElevatedButton]s.
+  final ButtonStyle elevatedButtonStyle;
+
+  /// The color that is used to create the [ButtonStyle]s.
+  final Color? errorColor;
+
+  /// The style for destructive [TextButton]s.
+  final ButtonStyle textButtonStyle;
+
+  @override
+  DestructiveButtons copyWith({Color? errorColor}) {
+    return DestructiveButtons(errorColor: errorColor);
+  }
+
+  @override
+  ThemeExtension<DestructiveButtons> lerp(
+    ThemeExtension<DestructiveButtons>? other,
+    double t,
+  ) {
+    if (other is! DestructiveButtons) {
+      return this;
+    }
+
+    return DestructiveButtons(
+      errorColor: Color.lerp(errorColor, other.errorColor, t),
+    );
+  }
+}
+
 /// This class represents the theme for the bottom bar
 /// on the manual ride attendee selection page.
 ///
@@ -168,43 +207,4 @@ class ScanStepperThemes {
     ),
     inactive: CupertinoColors.inactiveGray,
   );
-}
-
-/// This class defines a theme extension for destructive Material buttons.
-@immutable
-class DestructiveButtons extends ThemeExtension<DestructiveButtons> {
-  DestructiveButtons({
-    this.errorColor,
-  })  : elevatedButtonStyle = ElevatedButton.styleFrom(
-          backgroundColor: errorColor,
-        ),
-        textButtonStyle = TextButton.styleFrom(foregroundColor: errorColor);
-
-  /// The style for destructive [ElevatedButton]s.
-  final ButtonStyle elevatedButtonStyle;
-
-  /// The color that is used to create the [ButtonStyle]s.
-  final Color? errorColor;
-
-  /// The style for destructive [TextButton]s.
-  final ButtonStyle textButtonStyle;
-
-  @override
-  DestructiveButtons copyWith({Color? errorColor}) {
-    return DestructiveButtons(errorColor: errorColor);
-  }
-
-  @override
-  ThemeExtension<DestructiveButtons> lerp(
-    ThemeExtension<DestructiveButtons>? other,
-    double t,
-  ) {
-    if (other is! DestructiveButtons) {
-      return this;
-    }
-
-    return DestructiveButtons(
-      errorColor: Color.lerp(errorColor, other.errorColor, t),
-    );
-  }
 }


### PR DESCRIPTION
This PR inlines the `const TextStyle(color: Colors.white)` for the ride calendar.
This unblocks migrating the ride calendar theme to a new color palette.

It also sorts the destructive button theme extension to the top of the theme file.