### PR TITLE
Color scheme from seed

### DIFF
--- a/lib/widgets/pages/settings/settings_page.dart
+++ b/lib/widgets/pages/settings/settings_page.dart
@@ -141,7 +141,6 @@ class SettingsPageState extends ConsumerState<SettingsPage>
                 style: textTheme.titleMedium,
               ),
               Theme(
-                // TODO: remove when useMaterial3 is true in MaterialApp
                 data: ThemeData(useMaterial3: true, chipTheme: theme.chipTheme),
                 child: MemberListFilter(
                   initialFilter: memberFilterController.value,

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -39,7 +39,7 @@ abstract class AppTheme {
         ),
       ),
     ),
-    colorScheme: ColorScheme.fromSwatch(primarySwatch: Colors.blue),
+    colorScheme: colorScheme,
   );
 
   /// The color scheme for the MaterialApp.

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -96,6 +96,8 @@ class DestructiveButtons extends ThemeExtension<DestructiveButtons> {
   }
 }
 
+// TODO: deprecate this theme (blocked on Material 3 switch & bottom app bar)
+
 /// This class represents the theme for the bottom bar
 /// on the manual ride attendee selection page.
 ///


### PR DESCRIPTION
This PR changes the color scheme to come from a seed color rather than a swatch.

It also adds a TODO for the manual selection bottom app bar theme that should be deprecated,
and removes another TODO in favor of having a new task in the tracking issue.