### PR TITLE
Futures cleanup

### DIFF
--- a/integration_test/database_location_test.dart
+++ b/integration_test/database_location_test.dart
@@ -28,7 +28,7 @@ class FakeDatabase implements Database {
   final String path;
 
   @override
-  Future close() => Future.value();
+  Future close() async {}
 
   @override
   Future<T> transaction<T>(

--- a/lib/bluetooth/mock_bluetooth_scanner.dart
+++ b/lib/bluetooth/mock_bluetooth_scanner.dart
@@ -6,7 +6,7 @@ class MockBluetoothScanner implements BluetoothDeviceScanner {
   final _scanningController = BehaviorSubject.seeded(false);
 
   @override
-  Future<bool> isBluetoothEnabled() => Future.value(true);
+  Future<bool> isBluetoothEnabled() async => true;
 
   @override
   Stream<bool> get isScanning => _scanningController;

--- a/lib/database/device_dao.dart
+++ b/lib/database/device_dao.dart
@@ -78,7 +78,7 @@ class DeviceDaoImpl implements DeviceDao {
   @override
   Future<void> addDevice(Device device) async {
     if (await _deviceExists(device.name, device.ownerId)) {
-      return Future.error(DeviceExistsException());
+      throw DeviceExistsException();
     }
 
     return _database.transaction((txn) async {
@@ -147,7 +147,7 @@ class DeviceDaoImpl implements DeviceDao {
   @override
   Future<void> updateDevice(Device device) async {
     if (await _deviceExists(device.name, device.ownerId, device.creationDate)) {
-      return Future.error(DeviceExistsException());
+      throw DeviceExistsException();
     }
 
     return _database.transaction((txn) async {

--- a/lib/database/member_dao.dart
+++ b/lib/database/member_dao.dart
@@ -79,9 +79,7 @@ class MemberDaoImpl implements MemberDao {
     final recordRef = _memberStore.record(member.uuid);
 
     if (await recordRef.exists(_database)) {
-      return Future.error(
-        ArgumentError('The uuid ${member.uuid} is already in use'),
-      );
+      throw ArgumentError('The uuid ${member.uuid} is already in use');
     }
 
     final alias = member.alias;
@@ -89,7 +87,7 @@ class MemberDaoImpl implements MemberDao {
     final lastName = member.lastName;
 
     if (await _memberExists(firstName, lastName, alias)) {
-      return Future.error(RiderExistsException());
+      throw RiderExistsException();
     }
 
     await recordRef.add(_database, member.toMap());
@@ -167,7 +165,7 @@ class MemberDaoImpl implements MemberDao {
     final uuid = member.uuid;
 
     if (await _memberExists(firstName, lastName, alias, uuid)) {
-      return Future.error(RiderExistsException());
+      throw RiderExistsException();
     }
 
     await _memberStore.record(member.uuid).update(_database, member.toMap());

--- a/lib/file/file_handler.dart
+++ b/lib/file/file_handler.dart
@@ -52,7 +52,7 @@ class IoFileHandler implements FileHandler {
     }
 
     if (directory == null) {
-      return Future.error(ArgumentError.notNull('directory'));
+      throw ArgumentError.notNull('directory');
     }
 
     return File(directory.path + Platform.pathSeparator + fileName);
@@ -73,11 +73,11 @@ class IoFileHandler implements FileHandler {
     final ext = chosenFile.extension;
 
     if (ext == null || (!ext.endsWith('csv') && !ext.endsWith('json'))) {
-      return Future.error(UnsupportedFileFormatError());
+      throw UnsupportedFileFormatError();
     }
 
     if (chosenFile.path == null) {
-      return Future.error(UnsupportedFileFormatError());
+      throw UnsupportedFileFormatError();
     }
 
     return File(chosenFile.path!);

--- a/lib/model/member_form_delegate.dart
+++ b/lib/model/member_form_delegate.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
 import 'package:weforza/model/async_computation_delegate.dart';
@@ -32,17 +30,13 @@ class MemberFormDelegate extends AsyncComputationDelegate<void> {
       return;
     }
 
-    final image = await model.profileImage.catchError(
-      (_) => Future<File?>.value(),
-    );
-
     final member = Member(
       active: true,
       alias: model.alias,
       firstName: model.firstName,
       lastName: model.lastName,
       lastUpdated: DateTime.now(),
-      profileImageFilePath: image?.path,
+      profileImageFilePath: model.profileImage?.path,
       uuid: _uuidGenerator.v4(),
     );
 
@@ -76,17 +70,13 @@ class MemberFormDelegate extends AsyncComputationDelegate<void> {
         throw ArgumentError.notNull('uuid');
       }
 
-      final profileImage = await model.profileImage.catchError((error) {
-        return Future<File?>.value();
-      });
-
       final newMember = Member(
         active: model.activeMember,
         alias: model.alias,
         firstName: model.firstName,
         lastName: model.lastName,
         lastUpdated: DateTime.now(),
-        profileImageFilePath: profileImage?.path,
+        profileImageFilePath: model.profileImage?.path,
         uuid: uuid,
       );
 

--- a/lib/model/member_payload.dart
+++ b/lib/model/member_payload.dart
@@ -25,7 +25,7 @@ class MemberPayload {
   final String lastName;
 
   /// The file that represents the member's profile image.
-  final Future<File?> profileImage;
+  final File? profileImage;
 
   /// The uuid of the member, or null if the member should be created.
   final String? uuid;

--- a/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
+++ b/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
@@ -377,9 +377,7 @@ class RideAttendeeScanningDelegate {
   /// Returns the updated ride.
   Future<Ride> saveRideAttendeeSelection() async {
     if (_selectionLocked) {
-      return Future.error(
-        StateError('Cannot save the selection when it is locked.'),
-      );
+      throw StateError('Cannot save the selection when it is locked.');
     }
 
     _selectionLocked = true;
@@ -413,7 +411,7 @@ class RideAttendeeScanningDelegate {
         _stateMachine.addError(error);
       }
 
-      return Future.error(error);
+      rethrow;
     } finally {
       // Finally, unlock the selection.
       _selectionLocked = false;

--- a/lib/model/rider/import_riders_delegate.dart
+++ b/lib/model/rider/import_riders_delegate.dart
@@ -50,7 +50,7 @@ class ImportRidersDelegate {
   /// Returns the collection of [SerializableRider]s.
   ///
   /// Throws a [FormatException] if the file is malformed.
-  Future<Iterable<SerializableRider>> _readRidersFromFile(File file) {
+  Future<Iterable<SerializableRider>> _readRidersFromFile(File file) async {
     if (file.path.endsWith(ExportFileFormat.csv.formatExtension)) {
       return _readFileWithReader<String>(
         file,
@@ -65,7 +65,7 @@ class ImportRidersDelegate {
       );
     }
 
-    return Future.error(UnsupportedFileFormatError());
+    throw UnsupportedFileFormatError();
   }
 
   /// Import riders from a chosen file.

--- a/lib/riverpod/member/selected_member_attending_count_provider.dart
+++ b/lib/riverpod/member/selected_member_attending_count_provider.dart
@@ -2,14 +2,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/riverpod/member/selected_member_provider.dart';
 import 'package:weforza/riverpod/repository/member_repository_provider.dart';
 
-/// This provider provides the attending count for the selected member.
-final selectedMemberAttendingCountProvider = FutureProvider<int?>((ref) {
-  final member = ref.watch(selectedMemberProvider);
+// TODO: use select on the uuid to fix bug with active toggle
+
+/// This provider provides the attending count for the selected rider.
+final selectedMemberAttendingCountProvider = FutureProvider<int?>((ref) async {
+  final rider = ref.watch(selectedMemberProvider);
   final repository = ref.read(memberRepositoryProvider);
 
-  if (member == null) {
-    return Future.value();
+  if (rider == null) {
+    return null;
   }
 
-  return repository.getAttendingCount(member.uuid);
+  return repository.getAttendingCount(rider.uuid);
 });

--- a/lib/riverpod/member/selected_member_devices_provider.dart
+++ b/lib/riverpod/member/selected_member_devices_provider.dart
@@ -46,7 +46,7 @@ class SelectedMemberDevicesNotifier
   /// Add a device to the list of devices.
   Future<void> addDevice(DevicePayload model) async {
     if (state is! AsyncData<List<Device>>) {
-      return Future.error(StateError('The devices list was not loaded yet'));
+      throw StateError('The devices list was not loaded yet');
     }
 
     final device = Device(
@@ -68,7 +68,7 @@ class SelectedMemberDevicesNotifier
   /// Delete the device at [index].
   Future<void> deleteDevice(int index) async {
     if (state is! AsyncData<List<Device>>) {
-      return Future.error(StateError('The devices list was not loaded yet'));
+      throw StateError('The devices list was not loaded yet');
     }
 
     final newDevices = List.of(state.value!);
@@ -89,13 +89,13 @@ class SelectedMemberDevicesNotifier
   /// Edit the given device.
   Future<void> editDevice(DevicePayload model) async {
     if (state is! AsyncData<List<Device>>) {
-      return Future.error(StateError('The devices list was not loaded yet'));
+      throw StateError('The devices list was not loaded yet');
     }
 
     final creationDate = model.creationDate;
 
     if (creationDate == null) {
-      return Future.error(ArgumentError.notNull('creationDate'));
+      throw ArgumentError.notNull('creationDate');
     }
 
     final newDevice = Device(
@@ -118,7 +118,7 @@ class SelectedMemberDevicesNotifier
     );
 
     if (index == -1) {
-      return Future.error(ArgumentError.value(index));
+      throw ArgumentError.value(index);
     }
 
     newDevices[index] = newDevice;

--- a/lib/riverpod/member/selected_member_provider.dart
+++ b/lib/riverpod/member/selected_member_provider.dart
@@ -19,7 +19,7 @@ class SelectedMemberNotifier extends StateNotifier<Member?> {
     final member = state;
 
     if (member == null) {
-      return Future.error(ArgumentError.notNull('selected member'));
+      throw ArgumentError.notNull('member');
     }
 
     await ref.read(memberRepositoryProvider).deleteMember(member.uuid);

--- a/lib/riverpod/ride/selected_ride_provider.dart
+++ b/lib/riverpod/ride/selected_ride_provider.dart
@@ -10,13 +10,15 @@ final selectedRideProvider = StateNotifierProvider<SelectedRideNotifier, Ride?>(
   SelectedRideNotifier.new,
 );
 
+// TODO: use select on ride date
+
 /// This provider provides the list of attendees for the currently selected ride.
-final selectedRideAttendeesProvider = FutureProvider<List<Member>>((ref) {
+final selectedRideAttendeesProvider = FutureProvider<List<Member>>((ref) async {
   final repository = ref.watch(rideRepositoryProvider);
   final selectedRide = ref.watch(selectedRideProvider);
 
   if (selectedRide == null) {
-    return Future.error(ArgumentError.notNull('selectedRide'));
+    throw ArgumentError.notNull('selectedRide');
   }
 
   return repository.getRideAttendees(selectedRide.date);
@@ -31,7 +33,7 @@ class SelectedRideNotifier extends StateNotifier<Ride?> {
     final ride = state;
 
     if (ride == null) {
-      return Future.error(ArgumentError.notNull('ride'));
+      throw ArgumentError.notNull('ride');
     }
 
     await ref.read(rideRepositoryProvider).deleteRide(ride.date);

--- a/lib/widgets/custom/profile_image/profile_image_picker.dart
+++ b/lib/widgets/custom/profile_image/profile_image_picker.dart
@@ -2,102 +2,71 @@ import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/model/profile_image_picker_delegate.dart';
 import 'package:weforza/widgets/custom/profile_image/profile_image.dart';
 import 'package:weforza/widgets/platform/platform_aware_icon.dart';
 import 'package:weforza/widgets/platform/platform_aware_loading_indicator.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 
+/// This widget represents a profile image picker.
 class ProfileImagePicker extends StatelessWidget {
+  /// The default constructor.
   const ProfileImagePicker({
     required this.delegate,
     required this.size,
     super.key,
   });
 
+  /// The delegate for the picker.
   final ProfileImagePickerDelegate delegate;
 
+  /// The size for the picker.
   final double size;
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<SelectProfileImageState>(
+    final loading = SizedBox.square(
+      dimension: size,
+      child: const Center(child: PlatformAwareLoadingIndicator()),
+    );
+
+    return StreamBuilder<AsyncValue<File?>>(
+      initialData: delegate.selectedImage,
       stream: delegate.stream,
-      initialData: delegate.current,
       builder: (context, snapshot) {
-        if (snapshot.hasError) {
-          return const Center(
-            child: PlatformAwareIcon(
-              androidIcon: Icons.warning,
-              iosIcon: CupertinoIcons.exclamationmark_triangle_fill,
-            ),
-          );
-        }
-
-        final value = snapshot.data!;
-
-        final loading = SizedBox.square(
-          dimension: size,
-          child: const Center(child: PlatformAwareLoadingIndicator()),
-        );
-
-        if (value.selecting) {
-          return loading;
-        }
-
-        return GestureDetector(
-          onTap: delegate.pickImage,
-          onLongPress: delegate.clearImage,
-          child: PlatformAwareWidget(
-            android: (_) => _AsyncProfileImage(
-              future: value.image,
-              icon: Icons.camera_alt,
-              loading: loading,
-              size: size,
-            ),
-            ios: (_) => _AsyncProfileImage(
-              future: value.image,
-              icon: CupertinoIcons.camera_fill,
-              loading: loading,
-              size: size,
+        return snapshot.data!.when(
+          data: (image) => GestureDetector(
+            onLongPress: image == null ? null : delegate.clear,
+            onTap: delegate.selectImageFromGallery,
+            child: PlatformAwareWidget(
+              android: (_) => ProfileImage(
+                icon: Icons.camera_alt,
+                image: image,
+                loading: loading,
+                size: size,
+              ),
+              ios: (_) => ProfileImage(
+                icon: CupertinoIcons.camera_fill,
+                image: image,
+                loading: loading,
+                size: size,
+              ),
             ),
           ),
+          error: (error, stackTrace) => SizedBox.square(
+            dimension: size,
+            child: Center(
+              child: PlatformAwareIcon(
+                androidIcon: Icons.warning,
+                iosIcon: CupertinoIcons.exclamationmark_triangle_fill,
+                size: size / 2,
+              ),
+            ),
+          ),
+          loading: () => loading,
         );
       },
-    );
-  }
-}
-
-class _AsyncProfileImage extends StatelessWidget {
-  const _AsyncProfileImage({
-    required this.icon,
-    required this.loading,
-    required this.size,
-    this.future,
-  });
-
-  /// The future that represents the loading of the image.
-  final Future<File?>? future;
-
-  /// The icon that is used as fallback if the image is not available.
-  final IconData icon;
-
-  /// The widget that is displayed when the image is loading.
-  final Widget loading;
-
-  /// The size of this widget.
-  final double size;
-
-  @override
-  Widget build(BuildContext context) {
-    return FutureBuilder<File?>(
-      future: future,
-      builder: (context, snapshot) => ProfileImage(
-        icon: icon,
-        image: snapshot.data,
-        loading: loading,
-        size: size,
-      ),
     );
   }
 }

--- a/lib/widgets/pages/member_form.dart
+++ b/lib/widgets/pages/member_form.dart
@@ -67,7 +67,7 @@ class MemberFormState extends ConsumerState<MemberForm> with MemberValidator {
       alias: _aliasController.text,
       firstName: _firstNameController.text,
       lastName: _lastNameController.text,
-      profileImage: _profileImageDelegate.image,
+      profileImage: _profileImageDelegate.selectedImage.valueOrNull,
       uuid: memberUuid,
     );
 

--- a/lib/widgets/pages/member_form.dart
+++ b/lib/widgets/pages/member_form.dart
@@ -85,9 +85,7 @@ class MemberFormState extends ConsumerState<MemberForm> with MemberValidator {
 
     _profileImageDelegate = ProfileImagePickerDelegate(
       fileHandler: ref.read(fileHandlerProvider),
-      currentImage: Future.value(
-        profileImagePath == null ? null : File(profileImagePath),
-      ),
+      initialValue: profileImagePath == null ? null : File(profileImagePath),
     );
 
     _delegate = MemberFormDelegate(ref);

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list.dart
@@ -88,12 +88,12 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
   }
 
   /// Sort the active members on their name and alias.
-  Future<List<Member>> _sortActiveMembers() {
+  Future<List<Member>> _sortActiveMembers() async {
     final items = widget.delegate.activeMembers;
 
     items.sort((Member m1, Member m2) => m1.compareTo(m2));
 
-    return Future.value(items);
+    return items;
   }
 
   @override

--- a/lib/widgets/pages/ride_attendee_scanning_page/unresolved_owners_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/unresolved_owners_list.dart
@@ -30,12 +30,12 @@ class _UnresolvedOwnersListState extends State<UnresolvedOwnersList> {
 
   /// Filter out the owners that have already been scanned
   /// and sort the remaining unresolved owners.
-  Future<List<Member>> _filterAndSortItems() {
+  Future<List<Member>> _filterAndSortItems() async {
     final filtered = widget.delegate.getUnresolvedDeviceOwners();
 
     filtered.sort((Member m1, Member m2) => m1.compareTo(m2));
 
-    return Future.value(filtered);
+    return filtered;
   }
 
   TextStyle _getMultipleOwnersListDescriptionStyle(BuildContext context) {


### PR DESCRIPTION
This PR cleans up usages of `Future.value()` & `Future.error()` by replacing the former with `async` blocks and the latter with throw / rethrow.

It also cleans up the profile image picker to use an `AsyncValue<File?>` instead of `Future<File?>`

Fixes #257 