### PR TITLE
Scan page back button

### DIFF
--- a/lib/bluetooth/mock_bluetooth_scanner.dart
+++ b/lib/bluetooth/mock_bluetooth_scanner.dart
@@ -1,20 +1,14 @@
-import 'package:rxdart/subjects.dart';
+import 'package:rxdart/rxdart.dart';
 import 'package:weforza/bluetooth/bluetooth_device_scanner.dart';
 import 'package:weforza/bluetooth/bluetooth_peripheral.dart';
 
 class MockBluetoothScanner implements BluetoothDeviceScanner {
   final _scanningController = BehaviorSubject.seeded(false);
 
-  @override
-  Future<bool> isBluetoothEnabled() async => true;
+  final PublishSubject _stopScanPill = PublishSubject();
 
-  @override
-  Stream<bool> get isScanning => _scanningController;
-
-  @override
-  Stream<BluetoothPeripheral> scanForDevices(int scanDurationInSeconds) async* {
-    _scanningController.add(true);
-
+  /// Build a fale scan results stream.
+  Stream<BluetoothPeripheral> _buildScanResultsStream() async* {
     final duplicateOwner = BluetoothPeripheral(id: '1', deviceName: 'rudy1');
     final duplicateDevice = BluetoothPeripheral(
       id: '2',
@@ -25,7 +19,7 @@ class MockBluetoothScanner implements BluetoothDeviceScanner {
     final blankDeviceName = BluetoothPeripheral(id: '5', deviceName: '  ');
 
     for (int i = 0; i < 10; i++) {
-      await Future.delayed(const Duration(seconds: 2), () {});
+      await Future.delayed(const Duration(seconds: 2));
 
       if (i == 1) {
         yield* Stream.error(ArgumentError('some error'), StackTrace.current);
@@ -54,23 +48,43 @@ class MockBluetoothScanner implements BluetoothDeviceScanner {
       // Emit unknown devices as fallback.
       yield BluetoothPeripheral(id: '$i', deviceName: 'Device $i');
     }
-
-    if (!_scanningController.isClosed) {
-      _scanningController.add(false);
-    }
   }
 
   @override
-  Future<void> stopScan() {
-    if (!_scanningController.isClosed) {
-      _scanningController.add(false);
+  Future<bool> isBluetoothEnabled() async => true;
+
+  @override
+  Stream<bool> get isScanning => _scanningController;
+
+  @override
+  Stream<BluetoothPeripheral> scanForDevices(int scanDurationInSeconds) async* {
+    if (_scanningController.value) {
+      throw Exception('Another scan is already in progress.');
     }
 
-    return Future<void>.value();
+    _scanningController.add(true);
+
+    final killStreams = <Stream>[
+      _stopScanPill,
+      Rx.timer(null, Duration(seconds: scanDurationInSeconds)),
+    ];
+
+    yield* _buildScanResultsStream()
+        .takeUntil(Rx.merge(killStreams))
+        .doOnDone(stopScan);
+  }
+
+  @override
+  Future<void> stopScan() async {
+    if (!_scanningController.isClosed) {
+      _stopScanPill.add(null);
+      _scanningController.add(false);
+    }
   }
 
   @override
   void dispose() {
+    _stopScanPill.close();
     _scanningController.close();
   }
 }

--- a/lib/bluetooth/mock_bluetooth_scanner.dart
+++ b/lib/bluetooth/mock_bluetooth_scanner.dart
@@ -62,7 +62,9 @@ class MockBluetoothScanner implements BluetoothDeviceScanner {
 
   @override
   Future<void> stopScan() {
-    _scanningController.add(false);
+    if (!_scanningController.isClosed) {
+      _scanningController.add(false);
+    }
 
     return Future<void>.value();
   }

--- a/lib/exceptions/exceptions.dart
+++ b/lib/exceptions/exceptions.dart
@@ -12,6 +12,16 @@ class FileRequiredException extends ArgumentError {
 /// An exception that is thrown when a rider already exists.
 class RiderExistsException implements Exception {}
 
+/// An exception that is thrown
+/// when the scan results of a Bluetooth device scan could not be saved.
+class SaveScanResultsException implements Exception {}
+
+/// An exception that is thrown when a Bluetooth scanner could not be started.
+class StartScanException implements Exception {}
+
+/// An exception that is thrown when a Bluetooth scanner could not be stopped.
+class StopScanException implements Exception {}
+
 /// An exception that is thrown when a [File] was provided,
 /// but the given file format is not supported.
 class UnsupportedFileFormatError extends ArgumentError {

--- a/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
+++ b/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
@@ -93,6 +93,9 @@ class RideAttendeeScanningDelegate {
   /// The state machine for the scanning page.
   final _stateMachine = RideAttendeeScanningDelegateStateMachine();
 
+  /// The scroll controller for the scanning page stepper.
+  final _stepperScrollController = ScrollController();
+
   /// This set will contain all the owners
   /// that could not be resolved automatically.
   ///
@@ -117,6 +120,12 @@ class RideAttendeeScanningDelegate {
 
   /// Returns whether there are active members.
   bool get hasActiveMembers => _activeMembers.isNotEmpty;
+
+  /// Get the controller for the scan progress bar.
+  AnimationController get progressBarController => _scanProgressBarController;
+
+  /// Get the scroll controller for the scan stepper.
+  ScrollController get stepperScrollController => _stepperScrollController;
 
   /// Get the stream of state changes for the scan process.
   Stream<RideAttendeeScanningState> get stream => _stateMachine.stateStream;
@@ -562,5 +571,6 @@ class RideAttendeeScanningDelegate {
     _startScanningSubscription?.cancel();
     _startScanningSubscription = null;
     _scanProgressBarController.dispose();
+    _stepperScrollController.dispose();
   }
 }

--- a/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
+++ b/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
@@ -343,9 +343,21 @@ class RideAttendeeScanningDelegate {
     return true;
   }
 
+  /// Scroll the manual selection label into view.
+  void _scrollToManualSelectionLabel() {
+    if (_stepperScrollController.hasClients) {
+      _stepperScrollController.animateTo(
+        _stepperScrollController.position.maxScrollExtent,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.fastOutSlowIn,
+      );
+    }
+  }
+
   /// Go to the manual selection screen.
   void continueToManualSelection() {
     _stateMachine.setState(RideAttendeeScanningState.manualSelection);
+    _scrollToManualSelectionLabel();
   }
 
   /// Get the scanned device at the given [index].
@@ -389,6 +401,10 @@ class RideAttendeeScanningDelegate {
         : RideAttendeeScanningState.unresolvedOwnersSelection;
 
     _stateMachine.setState(newState);
+
+    if (newState == RideAttendeeScanningState.manualSelection) {
+      _scrollToManualSelectionLabel();
+    }
   }
 
   /// Save the current selection of ride attendees.

--- a/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
+++ b/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
@@ -447,6 +447,8 @@ class RideAttendeeScanningDelegate {
           // Ignore errors from individual events.
           // Otherwise the next scan results might be dropped.
         },
+        // Don't stop scanning even if an event was an error.
+        cancelOnError: false,
       );
     } catch (error) {
       if (!_stateMachine.isClosed) {

--- a/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
+++ b/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
@@ -98,6 +98,9 @@ class RideAttendeeScanningDelegate {
     return _rideAttendeeController.map((value) => value.length);
   }
 
+  /// Get the current state of the state machine.
+  RideAttendeeScanningState get currentState => _stateMachine.value;
+
   /// Returns whether there are active members.
   bool get hasActiveMembers => _activeMembers.isNotEmpty;
 

--- a/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate_state_machine.dart
+++ b/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate_state_machine.dart
@@ -1,0 +1,88 @@
+import 'package:rxdart/subjects.dart';
+import 'package:weforza/exceptions/exceptions.dart';
+import 'package:weforza/model/ride_attendee_scanning/ride_attendee_scanning_state.dart';
+
+/// This class represents a state machine for the [RideAttendeeScanningDelegate].
+class RideAttendeeScanningDelegateStateMachine {
+  /// The internal state machine.
+  final _controller = BehaviorSubject.seeded(
+    RideAttendeeScanningState.requestPermissions,
+  );
+
+  /// Get the current state of the state machine.
+  RideAttendeeScanningState get currentState => _controller.value;
+
+  /// Returns whether the state machine is closed and cannot be used anymore.
+  bool get isClosed => _controller.isClosed;
+
+  /// Determine whether the scanner should be stopped.
+  ///
+  /// Returns false if the scanner never started,
+  /// or if the scanner has already stopped.
+  ///
+  /// Returns true otherwise.
+  bool get shouldStopScanner {
+    // These states happen before the scan is running.
+    final beforeScanStates = <RideAttendeeScanningState>{
+      RideAttendeeScanningState.bluetoothDisabled,
+      RideAttendeeScanningState.permissionDenied,
+      RideAttendeeScanningState.requestPermissions,
+      RideAttendeeScanningState.startingScan,
+    };
+
+    final state = _controller.valueOrNull;
+    final stateError = _controller.errorOrNull;
+
+    // The scanner never started.
+    if (stateError == null && beforeScanStates.contains(state)) {
+      return false;
+    }
+
+    // The scanner failed to start because of a startup failure,
+    // i.e. Bluetooth was off, or the permission were denied.
+    if (stateError is StartScanException) {
+      return false;
+    }
+
+    // By the time a `SaveScanResultsException` occurs,
+    // the scanner has already stopped.
+    if (stateError is SaveScanResultsException) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /// Get a [Stream] of changes to the state of the state machine.
+  Stream<RideAttendeeScanningState> get stateStream => _controller;
+
+  /// Switch to the new [state].
+  void setState(RideAttendeeScanningState state) {
+    if (isClosed || _controller.value == state) {
+      return;
+    }
+
+    _controller.add(state);
+  }
+
+  /// Add [error] to the state machine.
+  void _setError(Object error) {
+    if (!isClosed) {
+      _controller.addError(error);
+    }
+  }
+
+  /// Add a [SaveScanResultsException] to the state machine.
+  void setSaveScanResultsError() => _setError(SaveScanResultsException());
+
+  /// Add a [StartScanException] to the state machine.
+  void setStartScanError() => _setError(StartScanException());
+
+  /// Add a [StopScanException] to the state machine.
+  void setStopScanError() => _setError(StopScanException());
+
+  /// Dispose of this state machine.
+  void dispose() {
+    _controller.close();
+  }
+}

--- a/lib/riverpod/bluetooth_provider.dart
+++ b/lib/riverpod/bluetooth_provider.dart
@@ -2,6 +2,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/bluetooth/bluetooth_device_scanner.dart';
 
 /// This provider provides the bluetooth scanner.
-final bluetoothProvider = Provider<BluetoothDeviceScanner>(
-  (_) => BluetoothDeviceScannerImpl(),
-);
+final bluetoothProvider = Provider.autoDispose<BluetoothDeviceScanner>((ref) {
+  final scanner = BluetoothDeviceScannerImpl();
+
+  ref.onDispose(scanner.dispose);
+
+  return scanner;
+});

--- a/lib/riverpod/database/database_provider.dart
+++ b/lib/riverpod/database/database_provider.dart
@@ -2,6 +2,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/database/database.dart';
 
 /// This provider provides the application database.
-final databaseProvider = Provider<ApplicationDatabase>(
-  (_) => ApplicationDatabase(),
-);
+final databaseProvider = Provider<ApplicationDatabase>((ref) {
+  final database = ApplicationDatabase();
+
+  ref.onDispose(database.dispose);
+
+  return database;
+});

--- a/lib/widgets/app.dart
+++ b/lib/widgets/app.dart
@@ -2,22 +2,15 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/generated/l10n.dart';
-import 'package:weforza/riverpod/database/database_provider.dart';
 import 'package:weforza/widgets/pages/home_page.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 import 'package:weforza/widgets/theme.dart';
 
 /// This class represents the application.
-class WeForzaApp extends ConsumerStatefulWidget {
+class WeForzaApp extends StatelessWidget {
   const WeForzaApp({super.key});
 
-  @override
-  WeForzaAppState createState() => WeForzaAppState();
-}
-
-class WeForzaAppState extends ConsumerState<WeForzaApp> {
   static const _appName = 'WeForza';
 
   @override
@@ -29,43 +22,29 @@ class WeForzaAppState extends ConsumerState<WeForzaApp> {
     ]);
 
     return PlatformAwareWidget(
-      android: _buildAndroidWidget,
-      ios: _buildIosWidget,
+      android: (_) => MaterialApp(
+        title: _appName,
+        localizationsDelegates: const [
+          S.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+        ],
+        supportedLocales: S.delegate.supportedLocales,
+        theme: AppTheme.androidTheme,
+        home: const HomePage(),
+      ),
+      ios: (_) => CupertinoApp(
+        title: _appName,
+        localizationsDelegates: const [
+          S.delegate,
+          GlobalCupertinoLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+        ],
+        supportedLocales: S.delegate.supportedLocales,
+        theme: AppTheme.iosTheme,
+        home: const HomePage(),
+      ),
     );
-  }
-
-  Widget _buildAndroidWidget(BuildContext context) {
-    return MaterialApp(
-      title: _appName,
-      localizationsDelegates: const [
-        S.delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ],
-      supportedLocales: S.delegate.supportedLocales,
-      theme: AppTheme.androidTheme,
-      home: const HomePage(),
-    );
-  }
-
-  Widget _buildIosWidget(BuildContext context) {
-    return CupertinoApp(
-      title: _appName,
-      localizationsDelegates: const [
-        S.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ],
-      supportedLocales: S.delegate.supportedLocales,
-      theme: AppTheme.iosTheme,
-      home: const HomePage(),
-    );
-  }
-
-  @override
-  void dispose() {
-    ref.read(databaseProvider).dispose();
-    super.dispose();
   }
 }

--- a/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
@@ -163,11 +163,11 @@ class PermissionDeniedError extends StatelessWidget {
       ),
       secondaryButton: PlatformAwareWidget(
         android: (context) => TextButton(
-          child: Text(translator.GoBack),
+          child: Text(translator.GoBackToDetailPage),
           onPressed: () => Navigator.of(context).pop(),
         ),
         ios: (context) => CupertinoButton(
-          child: Text(translator.GoBack),
+          child: Text(translator.GoBackToDetailPage),
           onPressed: () => Navigator.of(context).pop(),
         ),
       ),

--- a/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_page.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_page.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -31,13 +29,9 @@ class RideAttendeeScanningPage extends ConsumerStatefulWidget {
 class RideAttendeeScanningPageState
     extends ConsumerState<RideAttendeeScanningPage>
     with SingleTickerProviderStateMixin {
-  late final AnimationController _scanProgressBarController;
+  late final RideAttendeeScanningDelegate delegate;
 
   final GlobalKey<AnimatedListState> _scanResultsKey = GlobalKey();
-
-  StreamSubscription<bool>? _startScanningSubscription;
-
-  late final RideAttendeeScanningDelegate delegate;
 
   @override
   void initState() {
@@ -54,28 +48,6 @@ class RideAttendeeScanningPageState
       // the only thing left to do is to inset it into the animated list.
       onDeviceFound: (device) => _scanResultsKey.currentState?.insertItem(0),
     );
-
-    _scanProgressBarController = AnimationController(
-      duration: Duration(seconds: delegate.settings.scanDuration),
-      vsync: this,
-      value: 1.0,
-    );
-
-    // Setup a subscription that listens to the start of the device scan
-    // and starts the progress animation.
-    _startScanningSubscription = delegate.scanner.isScanning.listen((value) {
-      // If the subscription is null, the stream is or will be disposed.
-      if (_startScanningSubscription == null || !value) {
-        return;
-      }
-
-      // Start the animation when the scan stream emits the event
-      // that indicates that the scan started.
-      // The animation starts with a filled progress bar.
-      if (_scanProgressBarController.status == AnimationStatus.completed) {
-        _scanProgressBarController.reverse();
-      }
-    });
 
     delegate.startDeviceScan();
   }
@@ -164,9 +136,6 @@ class RideAttendeeScanningPageState
 
   @override
   void dispose() {
-    _startScanningSubscription?.cancel();
-    _startScanningSubscription = null;
-    _scanProgressBarController.dispose();
     delegate.dispose();
     super.dispose();
   }

--- a/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_page.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_page.dart
@@ -84,7 +84,6 @@ class RideAttendeeScanningPageState
     return Scaffold(
       resizeToAvoidBottomInset: false,
       appBar: AppBar(
-        automaticallyImplyLeading: false,
         title: RideAttendeeScanningStepper(
           stream: delegate.stateStream,
         ),
@@ -137,7 +136,6 @@ class RideAttendeeScanningPageState
       resizeToAvoidBottomInset: false,
       navigationBar: CupertinoNavigationBar(
         transitionBetweenRoutes: false,
-        automaticallyImplyLeading: false,
         middle: RideAttendeeScanningStepper(
           stream: delegate.stateStream,
         ),

--- a/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_page.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_page.dart
@@ -86,7 +86,6 @@ class RideAttendeeScanningPageState
       appBar: AppBar(
         automaticallyImplyLeading: false,
         title: RideAttendeeScanningStepper(
-          alignment: MainAxisAlignment.start,
           stream: delegate.stateStream,
         ),
       ),
@@ -140,7 +139,6 @@ class RideAttendeeScanningPageState
         transitionBetweenRoutes: false,
         automaticallyImplyLeading: false,
         middle: RideAttendeeScanningStepper(
-          alignment: MainAxisAlignment.center,
           stream: delegate.stateStream,
         ),
       ),

--- a/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_page.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_page.dart
@@ -44,6 +44,7 @@ class RideAttendeeScanningPageState
       rideRepository: ref.read(rideRepositoryProvider),
       scanner: ref.read(bluetoothProvider),
       settings: ref.read(settingsProvider),
+      vsync: this,
       // The delegate will have added the device to the scan results,
       // the only thing left to do is to inset it into the animated list.
       onDeviceFound: (device) => _scanResultsKey.currentState?.insertItem(0),
@@ -58,7 +59,8 @@ class RideAttendeeScanningPageState
       appBar: AppBar(
         title: RideAttendeeScanningStepper(
           initialData: delegate.currentState,
-          stream: delegate.stateStream,
+          scrollController: delegate.stepperScrollController,
+          stream: delegate.stream,
         ),
       ),
       body: _buildBody(),
@@ -67,7 +69,8 @@ class RideAttendeeScanningPageState
 
   Widget _buildBody() {
     return StreamBuilder<RideAttendeeScanningState>(
-      stream: delegate.stateStream,
+      initialData: delegate.currentState,
+      stream: delegate.stream,
       builder: (context, snapshot) {
         final state = snapshot.data;
 
@@ -92,7 +95,7 @@ class RideAttendeeScanningPageState
             return ScanResultsList(
               delegate: delegate,
               progressBar: ScanProgressIndicator(
-                animationController: _scanProgressBarController,
+                animationController: delegate.progressBarController,
                 isScanning: delegate.scanner.isScanning,
               ),
               scanResultsListKey: _scanResultsKey,
@@ -111,7 +114,8 @@ class RideAttendeeScanningPageState
         transitionBetweenRoutes: false,
         middle: RideAttendeeScanningStepper(
           initialData: delegate.currentState,
-          stream: delegate.stateStream,
+          scrollController: delegate.stepperScrollController,
+          stream: delegate.stream,
         ),
       ),
       child: SafeArea(

--- a/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_page.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_page.dart
@@ -85,6 +85,7 @@ class RideAttendeeScanningPageState
       resizeToAvoidBottomInset: false,
       appBar: AppBar(
         title: RideAttendeeScanningStepper(
+          initialData: delegate.currentState,
           stream: delegate.stateStream,
         ),
       ),
@@ -137,6 +138,7 @@ class RideAttendeeScanningPageState
       navigationBar: CupertinoNavigationBar(
         transitionBetweenRoutes: false,
         middle: RideAttendeeScanningStepper(
+          initialData: delegate.currentState,
           stream: delegate.stateStream,
         ),
       ),

--- a/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_page.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_page.dart
@@ -151,9 +151,12 @@ class RideAttendeeScanningPageState
 
   @override
   Widget build(BuildContext context) {
-    return PlatformAwareWidget(
-      android: _buildAndroidLayout,
-      ios: _buildIOSLayout,
+    return WillPopScope(
+      onWillPop: delegate.stopScan,
+      child: PlatformAwareWidget(
+        android: _buildAndroidLayout,
+        ios: _buildIOSLayout,
+      ),
     );
   }
 

--- a/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_stepper.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_stepper.dart
@@ -8,83 +8,110 @@ import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 /// It displays the two labels of the scanning process,
 /// `Scan` and `Manual`, separated by an arrow.
 class RideAttendeeScanningStepper extends StatelessWidget {
+  /// The default constructor.
   const RideAttendeeScanningStepper({
     required this.initialData,
+    required this.scrollController,
     required this.stream,
     super.key,
   });
 
-  /// The initial data for the [StreamBuilder].
+  /// The initial value for the stepper.
   final RideAttendeeScanningState initialData;
+
+  /// The controller for the horizontal scrollview that wraps the stepper.
+  final ScrollController scrollController;
 
   /// The stream that indicates the current step in the scanning process.
   final Stream<RideAttendeeScanningState> stream;
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<RideAttendeeScanningState>(
-      initialData: initialData,
-      stream: stream,
-      builder: (context, snapshot) {
-        // Every step before the manual selection should highlight the `Scan` label.
-        final isScanStep =
-            snapshot.data != RideAttendeeScanningState.manualSelection;
+    final translator = S.of(context);
+    final scanLabel = translator.Scan.toUpperCase();
+    final manualLabel = translator.Manual.toUpperCase();
 
-        final translator = S.of(context);
-        final scanLabel = translator.Scan.toUpperCase();
-        final manualLabel = translator.Manual.toUpperCase();
+    final separator = PlatformAwareWidget(
+      android: (_) => const Icon(Icons.chevron_right_rounded, size: 48),
+      ios: (_) => const Icon(
+        CupertinoIcons.chevron_forward,
+        color: CupertinoColors.inactiveGray,
+        size: 32,
+      ),
+    );
 
-        return PlatformAwareWidget(
-          android: (context) {
-            final activeColor = Colors.lime.shade300;
-            const inactiveColor = Colors.white;
+    return Scrollbar(
+      thumbVisibility: false,
+      trackVisibility: false,
+      controller: scrollController,
+      child: SingleChildScrollView(
+        controller: scrollController,
+        scrollDirection: Axis.horizontal,
+        physics: const NeverScrollableScrollPhysics(),
+        child: StreamBuilder<RideAttendeeScanningState>(
+          initialData: initialData,
+          stream: stream,
+          builder: (context, snapshot) {
+            // Every step before the manual selection should highlight the `Scan` label.
+            final isScanStep =
+                snapshot.data != RideAttendeeScanningState.manualSelection;
 
             return Row(
+              mainAxisSize: MainAxisSize.min,
               children: [
-                Text(
-                  scanLabel,
-                  style: TextStyle(
-                    color: isScanStep ? activeColor : inactiveColor,
-                  ),
+                _RideAttendeeScanningStepperLabel(
+                  isSelected: isScanStep,
+                  text: scanLabel,
                 ),
-                const Icon(Icons.chevron_right_rounded, size: 48),
-                Text(
-                  manualLabel,
-                  style: TextStyle(
-                    color: isScanStep ? inactiveColor : activeColor,
-                  ),
+                separator,
+                _RideAttendeeScanningStepperLabel(
+                  isSelected: !isScanStep,
+                  text: manualLabel,
                 ),
               ],
             );
           },
-          ios: (context) {
-            const activeColor = CupertinoColors.activeGreen;
-            const inactiveColor = CupertinoColors.inactiveGray;
+        ),
+      ),
+    );
+  }
+}
 
-            return Row(
-              children: [
-                Text(
-                  scanLabel,
-                  style: TextStyle(
-                    color: isScanStep ? activeColor : inactiveColor,
-                  ),
-                ),
-                const Icon(
-                  CupertinoIcons.chevron_forward,
-                  color: CupertinoColors.inactiveGray,
-                  size: 32,
-                ),
-                Text(
-                  manualLabel,
-                  style: TextStyle(
-                    color: isScanStep ? inactiveColor : activeColor,
-                  ),
-                ),
-              ],
-            );
-          },
-        );
-      },
+class _RideAttendeeScanningStepperLabel extends StatelessWidget {
+  const _RideAttendeeScanningStepperLabel({
+    required this.isSelected,
+    required this.text,
+  });
+
+  /// Whether this label is selected.
+  final bool isSelected;
+
+  /// The text for the label.
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    Color selectedColor;
+    Color unselectedColor;
+
+    switch (Theme.of(context).platform) {
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        selectedColor = Colors.lime.shade300;
+        unselectedColor = Colors.white;
+        break;
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        selectedColor = CupertinoColors.activeGreen;
+        unselectedColor = CupertinoColors.inactiveGray;
+        break;
+    }
+
+    return Text(
+      text,
+      style: TextStyle(color: isSelected ? selectedColor : unselectedColor),
     );
   }
 }

--- a/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_stepper.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_stepper.dart
@@ -9,9 +9,13 @@ import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 /// `Scan` and `Manual`, separated by an arrow.
 class RideAttendeeScanningStepper extends StatelessWidget {
   const RideAttendeeScanningStepper({
+    required this.initialData,
     required this.stream,
     super.key,
   });
+
+  /// The initial data for the [StreamBuilder].
+  final RideAttendeeScanningState initialData;
 
   /// The stream that indicates the current step in the scanning process.
   final Stream<RideAttendeeScanningState> stream;
@@ -19,6 +23,7 @@ class RideAttendeeScanningStepper extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<RideAttendeeScanningState>(
+      initialData: initialData,
       stream: stream,
       builder: (context, snapshot) {
         // Every step before the manual selection should highlight the `Scan` label.

--- a/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_stepper.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_stepper.dart
@@ -9,13 +9,9 @@ import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 /// `Scan` and `Manual`, separated by an arrow.
 class RideAttendeeScanningStepper extends StatelessWidget {
   const RideAttendeeScanningStepper({
-    required this.alignment,
     required this.stream,
     super.key,
   });
-
-  /// The alignment for the children of the stepper.
-  final MainAxisAlignment alignment;
 
   /// The stream that indicates the current step in the scanning process.
   final Stream<RideAttendeeScanningState> stream;
@@ -39,7 +35,6 @@ class RideAttendeeScanningStepper extends StatelessWidget {
             const inactiveColor = Colors.white;
 
             return Row(
-              mainAxisAlignment: alignment,
               children: [
                 Text(
                   scanLabel,
@@ -62,7 +57,6 @@ class RideAttendeeScanningStepper extends StatelessWidget {
             const inactiveColor = CupertinoColors.inactiveGray;
 
             return Row(
-              mainAxisAlignment: alignment,
               children: [
                 Text(
                   scanLabel,

--- a/lib/widgets/pages/ride_attendee_scanning_page/scan_results_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/scan_results_list.dart
@@ -29,27 +29,24 @@ class ScanResultsList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: delegate.stopScan,
-      child: Column(
-        children: [
-          progressBar,
-          Expanded(
-            child: AnimatedList(
-              key: scanResultsListKey,
-              itemBuilder: (context, index, animation) {
-                return SizeTransition(
-                  sizeFactor: animation,
-                  child: _ScanResultsListItem(
-                    device: delegate.getScannedDevice(index),
-                  ),
-                );
-              },
-            ),
+    return Column(
+      children: [
+        progressBar,
+        Expanded(
+          child: AnimatedList(
+            key: scanResultsListKey,
+            itemBuilder: (context, index, animation) {
+              return SizeTransition(
+                sizeFactor: animation,
+                child: _ScanResultsListItem(
+                  device: delegate.getScannedDevice(index),
+                ),
+              );
+            },
           ),
-          StopScanButton(delegate: delegate),
-        ],
-      ),
+        ),
+        StopScanButton(delegate: delegate),
+      ],
     );
   }
 }


### PR DESCRIPTION
This PR updates the scan page stepper to use a horizontal scroll view that automatically scrolls to the manual selection label when it becomes active.

It also fixes some minor `dispose()` issues.
Lastly the MockScanner has been fixed (it can now be used multiple times and doesn't fail to go back)

Fixes #193 