### PR TITLE
Fix profile image picker cancel result

### DIFF
--- a/lib/model/profile_image_picker_delegate.dart
+++ b/lib/model/profile_image_picker_delegate.dart
@@ -31,13 +31,25 @@ class ProfileImagePickerDelegate {
   /// Select a new image from the photo gallery.
   void selectImageFromGallery() async {
     try {
+      final previousFile = _controller.value.valueOrNull;
+
       _controller.add(const AsyncLoading());
 
       final file = await fileHandler.chooseProfileImageFromGallery();
 
-      if (!_controller.isClosed) {
-        _controller.add(AsyncValue.data(file));
+      if (_controller.isClosed) {
+        return;
       }
+
+      // If the result is null, but there was a previous file,
+      // use hte previous file as result.
+      if (previousFile != null && file == null) {
+        _controller.add(AsyncValue.data(previousFile));
+
+        return;
+      }
+
+      _controller.add(AsyncValue.data(file));
     } catch (error, stackTrace) {
       if (!_controller.isClosed) {
         _controller.add(AsyncValue.error(error, stackTrace));

--- a/lib/widgets/custom/profile_image/profile_image_picker_placeholder.dart
+++ b/lib/widgets/custom/profile_image/profile_image_picker_placeholder.dart
@@ -15,8 +15,6 @@ class CupertinoProfileImagePickerPlaceholder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final borderWidth = size / 16;
-
     return SizedBox.square(
       dimension: size,
       child: Stack(
@@ -34,7 +32,7 @@ class CupertinoProfileImagePickerPlaceholder extends StatelessWidget {
           Align(
             alignment: Alignment.bottomCenter,
             child: Transform.translate(
-              offset: Offset(0, borderWidth),
+              offset: Offset(0, size / 10),
               child: Icon(
                 CupertinoIcons.person_solid,
                 color: CupertinoColors.white,
@@ -48,7 +46,7 @@ class CupertinoProfileImagePickerPlaceholder extends StatelessWidget {
             decoration: BoxDecoration(
               border: Border.all(
                 color: CupertinoColors.systemGrey2,
-                width: borderWidth,
+                width: 3.0,
               ),
               borderRadius: BorderRadius.all(
                 Radius.circular(size / 2),

--- a/lib/widgets/pages/rider_form.dart
+++ b/lib/widgets/pages/rider_form.dart
@@ -295,7 +295,7 @@ class _RiderFormState extends ConsumerState<RiderForm> with RiderValidator {
                               const EdgeInsetsDirectional.fromSTEB(20, 6, 6, 6),
                           child: ProfileImagePicker(
                             delegate: _profileImageDelegate,
-                            imagePreviewSize: 64,
+                            imagePreviewSize: 80,
                             pickingIndicator: const SizedBox.square(
                               dimension: 88,
                               child: Center(


### PR DESCRIPTION
This PR fixes a bug with the profile image picker cancel result.

It also increases the preview size for iOS and improves upon the iOS placeholder border width.

Fixes #273 