### PR TITLE
Rename Member class to Rider

### DIFF
--- a/lib/database/export_rides_dao.dart
+++ b/lib/database/export_rides_dao.dart
@@ -18,7 +18,7 @@ class ExportRidesDaoImpl implements ExportRidesDao {
   /// A reference to the database.
   final Database _database;
 
-  /// A reference to the [Member] store.
+  /// A reference to the [Rider] store.
   final _memberStore = DatabaseTables.member;
 
   /// A reference to the [RideAttendee] store.
@@ -56,14 +56,14 @@ class ExportRidesDaoImpl implements ExportRidesDao {
     return attendees;
   }
 
-  /// Get all the members, mapped to their [Member.uuid].
-  Future<Map<String, Member>> _getMembers() async {
-    final members = <String, Member>{};
+  /// Get all the members, mapped to their [Rider.uuid].
+  Future<Map<String, Rider>> _getMembers() async {
+    final members = <String, Rider>{};
 
     final records = await _memberStore.find(_database);
 
     for (final record in records) {
-      final member = Member.of(record.key, record.value);
+      final member = Rider.of(record.key, record.value);
       members[member.uuid] = member;
     }
 
@@ -96,7 +96,7 @@ class ExportRidesDaoImpl implements ExportRidesDao {
 
   Iterable<ExportableRide> _joinRidesAndAttendees(
     Map<DateTime, Set<RideAttendee>> attendees,
-    Map<String, Member> members,
+    Map<String, Rider> members,
     Map<DateTime, Ride> rides,
   ) {
     final exports = <ExportableRide>[];

--- a/lib/database/import_riders_dao.dart
+++ b/lib/database/import_riders_dao.dart
@@ -46,8 +46,8 @@ class ImportRidersDaoImpl implements ImportRidersDao {
 
   /// Get the existing riders.
   /// Returns a map of [Rider]s mapped to their respective [SerializableRiderKey]s.
-  Future<Map<SerializableRiderKey, Member>> _getExistingRiders() async {
-    final collection = <SerializableRiderKey, Member>{};
+  Future<Map<SerializableRiderKey, Rider>> _getExistingRiders() async {
+    final collection = <SerializableRiderKey, Rider>{};
 
     final records = await _riderStore.find(_database);
 
@@ -59,7 +59,7 @@ class ImportRidersDaoImpl implements ImportRidersDao {
       );
 
       if (collection[key] == null) {
-        collection[key] = Member.of(record.key, record.value);
+        collection[key] = Rider.of(record.key, record.value);
       }
     }
 
@@ -82,7 +82,7 @@ class ImportRidersDaoImpl implements ImportRidersDao {
     final ridersToUpdate = <SerializableRiderUpdateTimestamp>{};
 
     // The new riders that should be added.
-    final newRiders = <Member>{};
+    final newRiders = <Rider>{};
 
     // The new devices that should be added.
     final newDevices = <Device>{};
@@ -98,7 +98,7 @@ class ImportRidersDaoImpl implements ImportRidersDao {
         final uuid = uuidGenerator.v4();
 
         newRiders.add(
-          Member(
+          Rider(
             active: rider.active,
             alias: rider.alias,
             firstName: rider.firstName,

--- a/lib/database/member_dao.dart
+++ b/lib/database/member_dao.dart
@@ -9,7 +9,7 @@ import 'package:weforza/model/rider/rider.dart';
 /// This class defines an interface to work with members.
 abstract class MemberDao {
   /// Add a [member].
-  Future<void> addMember(Member member);
+  Future<void> addMember(Rider member);
 
   /// Delete the member with the given [uuid].
   Future<void> deleteMember(String uuid);
@@ -18,13 +18,13 @@ abstract class MemberDao {
   Future<int> getAttendingCount(String uuid);
 
   /// Get the list of members that satisfy the given [filter].
-  Future<List<Member>> getMembers(MemberFilterOption filter);
+  Future<List<Rider>> getMembers(MemberFilterOption filter);
 
   /// Toggle the active state of the member with the given [uuid].
   Future<void> setMemberActive(String uuid, {required bool value});
 
   /// Update the given [member].
-  Future<void> updateMember(Member member);
+  Future<void> updateMember(Rider member);
 }
 
 /// This class represents the default implementation of [MemberDao].
@@ -38,7 +38,7 @@ class MemberDaoImpl implements MemberDao {
   /// A reference to the [Device] store.
   final _deviceStore = DatabaseTables.device;
 
-  /// A reference to the [Member] store.
+  /// A reference to the [Rider] store.
   final _memberStore = DatabaseTables.member;
 
   /// A reference to the [RideAttendee] store.
@@ -74,7 +74,7 @@ class MemberDaoImpl implements MemberDao {
   }
 
   @override
-  Future<void> addMember(Member member) async {
+  Future<void> addMember(Rider member) async {
     final recordRef = _memberStore.record(member.uuid);
 
     if (await recordRef.exists(_database)) {
@@ -116,7 +116,7 @@ class MemberDaoImpl implements MemberDao {
   }
 
   @override
-  Future<List<Member>> getMembers(MemberFilterOption filter) async {
+  Future<List<Rider>> getMembers(MemberFilterOption filter) async {
     final finder = Finder(
       sortOrders: [
         SortOrder('firstname'),
@@ -138,7 +138,7 @@ class MemberDaoImpl implements MemberDao {
 
     final records = await _memberStore.find(_database, finder: finder);
 
-    return records.map((r) => Member.of(r.key, r.value)).toList();
+    return records.map((r) => Rider.of(r.key, r.value)).toList();
   }
 
   @override
@@ -157,7 +157,7 @@ class MemberDaoImpl implements MemberDao {
   }
 
   @override
-  Future<void> updateMember(Member member) async {
+  Future<void> updateMember(Rider member) async {
     final alias = member.alias;
     final firstName = member.firstName;
     final lastName = member.lastName;

--- a/lib/database/ride_dao.dart
+++ b/lib/database/ride_dao.dart
@@ -17,7 +17,7 @@ abstract class RideDao {
   Future<void> deleteRideCalendar();
 
   /// Get the attendees of the ride with the given [date].
-  Future<List<Member>> getRideAttendees(DateTime date);
+  Future<List<Rider>> getRideAttendees(DateTime date);
 
   /// Get the dates of the rides in the calendar.
   Future<List<DateTime>> getRideDates();
@@ -45,7 +45,7 @@ class RideDaoImpl implements RideDao {
   /// A reference to the database.
   final Database _database;
 
-  /// A reference to the [Member] store.
+  /// A reference to the [Rider] store.
   final _memberStore = DatabaseTables.member;
 
   /// A reference to the [RideAttendee] store.
@@ -86,7 +86,7 @@ class RideDaoImpl implements RideDao {
   }
 
   @override
-  Future<List<Member>> getRideAttendees(DateTime date) async {
+  Future<List<Rider>> getRideAttendees(DateTime date) async {
     final rideAttendees = await _rideAttendeeStore.find(
       _database,
       finder: Finder(filter: Filter.equals('date', date.toIso8601String())),
@@ -106,7 +106,7 @@ class RideDaoImpl implements RideDao {
       ),
     );
 
-    return memberRecords.map((r) => Member.of(r.key, r.value)).toList();
+    return memberRecords.map((r) => Rider.of(r.key, r.value)).toList();
   }
 
   @override

--- a/lib/file/import_riders_csv_reader.dart
+++ b/lib/file/import_riders_csv_reader.dart
@@ -82,7 +82,7 @@ class ImportRidersCsvReader implements ImportRidersFileReader<String> {
     final lastName = cells[1];
     final alias = cells[2];
 
-    final regex = Member.personNameAndAliasRegex;
+    final regex = Rider.personNameAndAliasRegex;
 
     // If the first name, last name or alias is invalid, skip this chunk.
     if (!regex.hasMatch(firstName) ||

--- a/lib/file/import_riders_json_reader.dart
+++ b/lib/file/import_riders_json_reader.dart
@@ -20,7 +20,7 @@ class ImportRidersJsonReader
       final firstName = chunk['firstName'] as String;
       final lastName = chunk['lastName'] as String;
 
-      final regex = Member.personNameAndAliasRegex;
+      final regex = Rider.personNameAndAliasRegex;
 
       // If the first name, last name or alias is invalid, skip this chunk.
       if (!regex.hasMatch(firstName) ||

--- a/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
+++ b/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
@@ -63,8 +63,8 @@ class RideAttendeeScanningDelegate {
   /// The settings for the delegate.
   final Settings settings;
 
-  /// This map contains all the active members mapped to their [Member.uuid].
-  final _activeMembers = <String, Member>{};
+  /// This map contains all the active members mapped to their [Rider.uuid].
+  final _activeMembers = <String, Rider>{};
 
   /// This map contains the uuids of owners per device name.
   ///
@@ -102,10 +102,10 @@ class RideAttendeeScanningDelegate {
   /// An owner cannot be resolved automatically
   /// if a scanned device has two or more possible owners,
   /// because then there are multiple valid options.
-  final _unresolvedOwners = <Member>{};
+  final _unresolvedOwners = <Rider>{};
 
   /// Get the list of active members.
-  List<Member> get activeMembers => _activeMembers.values.toList();
+  List<Rider> get activeMembers => _activeMembers.values.toList();
 
   /// Get the amount of selected ride attendees.
   int get attendeeCount => _rideAttendeeController.value.length;
@@ -377,10 +377,10 @@ class RideAttendeeScanningDelegate {
 
   /// Get the list of unresolved device owners
   /// that have not yet been scanned automatically.
-  List<Member> getUnresolvedDeviceOwners() {
+  List<Rider> getUnresolvedDeviceOwners() {
     final rideAttendees = _rideAttendeeController.value;
 
-    return _unresolvedOwners.where((Member member) {
+    return _unresolvedOwners.where((Rider member) {
       return !rideAttendees.contains(
         ScannedRideAttendee(uuid: member.uuid, isScanned: false),
       );

--- a/lib/model/ride_attendee_scanning/scanned_device.dart
+++ b/lib/model/ride_attendee_scanning/scanned_device.dart
@@ -8,5 +8,5 @@ class ScannedDevice {
   final String name;
 
   /// The possible owners of the scanned device.
-  final List<Member> owners;
+  final List<Rider> owners;
 }

--- a/lib/model/rider/rider.dart
+++ b/lib/model/rider/rider.dart
@@ -1,9 +1,9 @@
 import 'package:weforza/extensions/date_extension.dart';
 
 /// This class represents a rider.
-class Member implements Comparable<Member> {
+class Rider implements Comparable<Rider> {
   /// The default constuctor.
-  Member({
+  Rider({
     required this.active,
     required this.alias,
     required this.firstName,
@@ -17,10 +17,10 @@ class Member implements Comparable<Member> {
         );
 
   /// Create a rider from the given [uuid] and [values].
-  factory Member.of(String uuid, Map<String, Object?> values) {
+  factory Rider.of(String uuid, Map<String, Object?> values) {
     assert(uuid.isNotEmpty, 'The uuid of a rider should not be empty');
 
-    return Member(
+    return Rider(
       active: values['active'] as bool? ?? true,
       alias: values['alias'] as String? ?? '',
       firstName: values['firstname'] as String,
@@ -69,7 +69,7 @@ class Member implements Comparable<Member> {
   String get initials => firstName[0] + lastName[0];
 
   @override
-  int compareTo(Member other) {
+  int compareTo(Rider other) {
     final int deltaFirstName = firstName.compareTo(other.firstName);
 
     if (deltaFirstName != 0) {
@@ -112,7 +112,7 @@ class Member implements Comparable<Member> {
 
   @override
   bool operator ==(Object other) {
-    return other is Member &&
+    return other is Rider &&
         uuid == other.uuid &&
         firstName == other.firstName &&
         lastName == other.lastName &&

--- a/lib/model/rider/rider.dart
+++ b/lib/model/rider/rider.dart
@@ -1,6 +1,6 @@
 import 'package:weforza/extensions/date_extension.dart';
 
-/// This class represents a member.
+/// This class represents a rider.
 class Member implements Comparable<Member> {
   /// The default constuctor.
   Member({
@@ -13,12 +13,12 @@ class Member implements Comparable<Member> {
     required this.uuid,
   }) : assert(
           uuid.isNotEmpty && firstName.isNotEmpty && lastName.isNotEmpty,
-          'The uuid, first name and last name of a member should not be empty',
+          'The uuid, first name and last name of a rider should not be empty',
         );
 
-  /// Create a member from the given [uuid] and [values].
+  /// Create a rider from the given [uuid] and [values].
   factory Member.of(String uuid, Map<String, Object?> values) {
-    assert(uuid.isNotEmpty, 'The uuid of a member should not be empty');
+    assert(uuid.isNotEmpty, 'The uuid of a rider should not be empty');
 
     return Member(
       active: values['active'] as bool? ?? true,
@@ -31,7 +31,7 @@ class Member implements Comparable<Member> {
     );
   }
 
-  /// Regex for a member's first name, last name or alias.
+  /// Regex for a rider's first name, last name or alias.
   ///
   /// The regex is language independent,
   /// allows hyphens, apostrophes and spaces,
@@ -44,28 +44,28 @@ class Member implements Comparable<Member> {
   /// The maximum length for the first name, last name and alias.
   static const int nameAndAliasMaxLength = 50;
 
-  /// Whether this member is currently an active ride participant.
+  /// Whether this rider is currently an active ride participant.
   final bool active;
 
-  /// The member's alias.
+  /// The rider's alias.
   final String alias;
 
-  /// The member's first name.
+  /// The rider's first name.
   final String firstName;
 
-  /// The member's last name.
+  /// The rider's last name.
   final String lastName;
 
-  /// The last time that this member was updated.
+  /// The last time that this rider was updated.
   final DateTime lastUpdated;
 
-  /// The path to the member's profile image on disk.
+  /// The path to the rider's profile image on disk.
   final String? profileImageFilePath;
 
-  /// The member's UUID.
+  /// The rider's UUID.
   final String uuid;
 
-  /// Get the member's initials.
+  /// Get the rider's initials.
   String get initials => firstName[0] + lastName[0];
 
   @override
@@ -85,7 +85,7 @@ class Member implements Comparable<Member> {
     return alias.compareTo(other.alias);
   }
 
-  /// Convert this member into a map.
+  /// Convert this rider into a map.
   Map<String, Object?> toMap() {
     return {
       'active': active,

--- a/lib/model/rider/rider_form_delegate.dart
+++ b/lib/model/rider/rider_form_delegate.dart
@@ -24,7 +24,7 @@ class RiderFormDelegate extends AsyncComputationDelegate<void> {
       return;
     }
 
-    final rider = Member(
+    final rider = Rider(
       active: true,
       alias: model.alias,
       firstName: model.firstName,
@@ -51,7 +51,7 @@ class RiderFormDelegate extends AsyncComputationDelegate<void> {
   /// the [whenComplete] function is called with the updated rider.
   void editRider(
     RiderModel model, {
-    required void Function(Member updatedRider) whenComplete,
+    required void Function(Rider updatedRider) whenComplete,
   }) async {
     if (!canStartComputation()) {
       return;
@@ -64,7 +64,7 @@ class RiderFormDelegate extends AsyncComputationDelegate<void> {
         throw ArgumentError.notNull('uuid');
       }
 
-      final updatedRider = Member(
+      final updatedRider = Rider(
         active: model.active,
         alias: model.alias,
         firstName: model.firstName,

--- a/lib/model/rider/rider_validator.dart
+++ b/lib/model/rider/rider_validator.dart
@@ -13,11 +13,11 @@ mixin RiderValidator {
       return isBlankMessage;
     }
 
-    if (value.length > Member.nameAndAliasMaxLength) {
+    if (value.length > Rider.nameAndAliasMaxLength) {
       return maxLengthMessage;
     }
 
-    if (value.isNotEmpty && !Member.personNameAndAliasRegex.hasMatch(value)) {
+    if (value.isNotEmpty && !Rider.personNameAndAliasRegex.hasMatch(value)) {
       return illegalCharachterMessage;
     }
 
@@ -39,11 +39,11 @@ mixin RiderValidator {
       return isBlankMessage;
     }
 
-    if (value.length > Member.nameAndAliasMaxLength) {
+    if (value.length > Rider.nameAndAliasMaxLength) {
       return maxLengthMessage;
     }
 
-    if (!Member.personNameAndAliasRegex.hasMatch(value)) {
+    if (!Rider.personNameAndAliasRegex.hasMatch(value)) {
       return illegalCharachterMessage;
     }
 

--- a/lib/repository/member_repository.dart
+++ b/lib/repository/member_repository.dart
@@ -10,13 +10,13 @@ class MemberRepository {
 
   final MemberDao _dao;
 
-  Future<void> addMember(Member member) => _dao.addMember(member);
+  Future<void> addMember(Rider member) => _dao.addMember(member);
 
   Future<void> deleteMember(String uuid) => _dao.deleteMember(uuid);
 
   Future<int> getAttendingCount(String uuid) => _dao.getAttendingCount(uuid);
 
-  Future<List<Member>> getMembers(MemberFilterOption filter) {
+  Future<List<Rider>> getMembers(MemberFilterOption filter) {
     return _dao.getMembers(filter);
   }
 
@@ -24,5 +24,5 @@ class MemberRepository {
     return _dao.setMemberActive(uuid, value: value);
   }
 
-  Future<void> updateMember(Member member) => _dao.updateMember(member);
+  Future<void> updateMember(Rider member) => _dao.updateMember(member);
 }

--- a/lib/repository/ride_repository.dart
+++ b/lib/repository/ride_repository.dart
@@ -16,7 +16,7 @@ class RideRepository {
 
   Future<void> deleteRideCalendar() => _dao.deleteRideCalendar();
 
-  Future<List<Member>> getRideAttendees(DateTime date) {
+  Future<List<Rider>> getRideAttendees(DateTime date) {
     return _dao.getRideAttendees(date);
   }
 

--- a/lib/riverpod/member/member_list_provider.dart
+++ b/lib/riverpod/member/member_list_provider.dart
@@ -5,7 +5,7 @@ import 'package:weforza/riverpod/repository/member_repository_provider.dart';
 import 'package:weforza/riverpod/settings_provider.dart';
 
 /// This provider provides the list of members.
-final memberListProvider = FutureProvider<List<Member>>((ref) {
+final memberListProvider = FutureProvider<List<Rider>>((ref) {
   final repository = ref.read(memberRepositoryProvider);
 
   // Watch the member list filter for changes.

--- a/lib/riverpod/member/selected_member_provider.dart
+++ b/lib/riverpod/member/selected_member_provider.dart
@@ -6,11 +6,11 @@ import 'package:weforza/riverpod/ride/selected_ride_provider.dart';
 
 /// This provider manages the selected member.
 final selectedMemberProvider =
-    StateNotifierProvider<SelectedMemberNotifier, Member?>(
+    StateNotifierProvider<SelectedMemberNotifier, Rider?>(
   SelectedMemberNotifier.new,
 );
 
-class SelectedMemberNotifier extends StateNotifier<Member?> {
+class SelectedMemberNotifier extends StateNotifier<Rider?> {
   SelectedMemberNotifier(this.ref) : super(null);
 
   final Ref ref;
@@ -43,7 +43,7 @@ class SelectedMemberNotifier extends StateNotifier<Member?> {
 
       await repository.setMemberActive(member.uuid, value: value);
 
-      state = Member(
+      state = Rider(
         active: value,
         alias: member.alias,
         firstName: member.firstName,
@@ -59,7 +59,7 @@ class SelectedMemberNotifier extends StateNotifier<Member?> {
     }
   }
 
-  void setSelectedMember(Member member) {
+  void setSelectedMember(Rider member) {
     if (state != member) {
       state = member;
     }

--- a/lib/riverpod/ride/selected_ride_provider.dart
+++ b/lib/riverpod/ride/selected_ride_provider.dart
@@ -11,7 +11,7 @@ final selectedRideProvider = StateNotifierProvider<SelectedRideNotifier, Ride?>(
 );
 
 /// This provider provides the list of attendees for the currently selected ride.
-final selectedRideAttendeesProvider = FutureProvider<List<Member>>((ref) async {
+final selectedRideAttendeesProvider = FutureProvider<List<Rider>>((ref) async {
   final repository = ref.watch(rideRepositoryProvider);
   final selectedRide = ref.watch(selectedRideProvider);
 

--- a/lib/widgets/common/member_attending_count.dart
+++ b/lib/widgets/common/member_attending_count.dart
@@ -79,7 +79,7 @@ class MemberListItemAttendingCount extends ConsumerWidget {
     super.key,
   });
 
-  final Member member;
+  final Rider member;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/widgets/pages/member_details/member_details_page.dart
+++ b/lib/widgets/pages/member_details/member_details_page.dart
@@ -15,11 +15,11 @@ import 'package:weforza/widgets/pages/rider_form.dart';
 import 'package:weforza/widgets/platform/cupertino_icon_button.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 
-/// This class represents the detail page for a [Member].
+/// This class represents the detail page for a [Rider].
 class MemberDetailsPage extends StatelessWidget {
   const MemberDetailsPage({super.key});
 
-  void _goToEditMemberPage(BuildContext context, Member rider) {
+  void _goToEditMemberPage(BuildContext context, Rider rider) {
     Navigator.push(
       context,
       MaterialPageRoute(builder: (context) => RiderForm(rider: rider)),

--- a/lib/widgets/pages/member_list/member_list.dart
+++ b/lib/widgets/pages/member_list/member_list.dart
@@ -21,7 +21,7 @@ class MemberList extends ConsumerWidget {
   });
 
   /// The function that handles filtering results.
-  final List<Member> Function(List<Member> data, String query) filter;
+  final List<Rider> Function(List<Rider> data, String query) filter;
 
   /// The function that is called after a member is selected.
   final void Function() onMemberSelected;

--- a/lib/widgets/pages/member_list/member_list_item.dart
+++ b/lib/widgets/pages/member_list/member_list_item.dart
@@ -16,7 +16,7 @@ class MemberListItem extends ConsumerWidget {
   }) : super(key: ValueKey(member.uuid));
 
   /// The member that is displayed in this item.
-  final Member member;
+  final Rider member;
 
   /// The onTap handler for this item.
   ///

--- a/lib/widgets/pages/member_list/member_list_page.dart
+++ b/lib/widgets/pages/member_list/member_list_page.dart
@@ -39,7 +39,7 @@ class MemberListPageState extends ConsumerState<MemberListPage> {
   }
 
   /// Filter the given [list] on the current [searchQuery].
-  List<Member> _filterOnSearchQuery(List<Member> list, String searchQuery) {
+  List<Rider> _filterOnSearchQuery(List<Rider> list, String searchQuery) {
     final query = searchQuery.trim().toLowerCase();
 
     if (query.isEmpty) {

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list.dart
@@ -33,14 +33,14 @@ class ManualSelectionList extends StatefulWidget {
 }
 
 class _ManualSelectionListState extends State<ManualSelectionList> {
-  Future<List<Member>>? _activeMembersFuture;
+  Future<List<Rider>>? _activeMembersFuture;
 
   final _filtersController = ManualSelectionFilterDelegate();
 
   Future<void>? _saveFuture;
 
-  List<Member> _filterActiveMembers(
-    List<Member> items,
+  List<Rider> _filterActiveMembers(
+    List<Rider> items,
     ManualSelectionFilterOptions filters,
   ) {
     return items.where((item) {
@@ -88,10 +88,10 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
   }
 
   /// Sort the active members on their name and alias.
-  Future<List<Member>> _sortActiveMembers() async {
+  Future<List<Rider>> _sortActiveMembers() async {
     final items = widget.delegate.activeMembers;
 
-    items.sort((Member m1, Member m2) => m1.compareTo(m2));
+    items.sort((Rider m1, Rider m2) => m1.compareTo(m2));
 
     return items;
   }
@@ -105,7 +105,7 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
     }
   }
 
-  Widget _buildActiveMembersList(BuildContext context, List<Member> items) {
+  Widget _buildActiveMembersList(BuildContext context, List<Rider> items) {
     final translator = S.of(context);
 
     return FocusAbsorber(
@@ -178,7 +178,7 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
   @override
   Widget build(BuildContext context) {
     if (widget.delegate.hasActiveMembers) {
-      return FutureBuilder<List<Member>>(
+      return FutureBuilder<List<Rider>>(
         future: _activeMembersFuture,
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.done) {

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_item.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_item.dart
@@ -19,7 +19,7 @@ class ManualSelectionListItem extends ConsumerStatefulWidget {
 
   final RideAttendeeScanningDelegate delegate;
 
-  final Member item;
+  final Rider item;
 
   @override
   ConsumerState<ManualSelectionListItem> createState() =>

--- a/lib/widgets/pages/ride_attendee_scanning_page/unresolved_owners_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/unresolved_owners_list.dart
@@ -26,14 +26,14 @@ class UnresolvedOwnersList extends StatefulWidget {
 }
 
 class _UnresolvedOwnersListState extends State<UnresolvedOwnersList> {
-  Future<List<Member>>? _future;
+  Future<List<Rider>>? _future;
 
   /// Filter out the owners that have already been scanned
   /// and sort the remaining unresolved owners.
-  Future<List<Member>> _filterAndSortItems() async {
+  Future<List<Rider>> _filterAndSortItems() async {
     final filtered = widget.delegate.getUnresolvedDeviceOwners();
 
-    filtered.sort((Member m1, Member m2) => m1.compareTo(m2));
+    filtered.sort((Rider m1, Rider m2) => m1.compareTo(m2));
 
     return filtered;
   }
@@ -65,7 +65,7 @@ class _UnresolvedOwnersListState extends State<UnresolvedOwnersList> {
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<List<Member>>(
+    return FutureBuilder<List<Rider>>(
       future: _future,
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.done) {
@@ -122,7 +122,7 @@ class _UnresolvedOwnersListItem extends StatefulWidget {
 
   final RideAttendeeScanningDelegate delegate;
 
-  final Member item;
+  final Rider item;
 
   @override
   State<_UnresolvedOwnersListItem> createState() =>

--- a/lib/widgets/pages/rider_form.dart
+++ b/lib/widgets/pages/rider_form.dart
@@ -25,7 +25,7 @@ class RiderForm extends ConsumerStatefulWidget {
   /// The rider to edit.
   ///
   /// If this is null, a new rider will be created instead.
-  final Member? rider;
+  final Rider? rider;
 
   @override
   ConsumerState<RiderForm> createState() => _RiderFormState();
@@ -195,7 +195,7 @@ class _RiderFormState extends ConsumerState<RiderForm> with RiderValidator {
                       value: value,
                       requiredMessage: strings.FirstNameRequired,
                       maxLengthMessage: strings.FirstNameMaxLength(
-                        Member.nameAndAliasMaxLength,
+                        Rider.nameAndAliasMaxLength,
                       ),
                       illegalCharachterMessage:
                           strings.FirstNameIllegalCharacters,
@@ -224,7 +224,7 @@ class _RiderFormState extends ConsumerState<RiderForm> with RiderValidator {
                       value: value,
                       requiredMessage: strings.LastNameRequired,
                       maxLengthMessage: strings.LastNameMaxLength(
-                        Member.nameAndAliasMaxLength,
+                        Rider.nameAndAliasMaxLength,
                       ),
                       illegalCharachterMessage:
                           strings.LastNameIllegalCharacters,
@@ -249,7 +249,7 @@ class _RiderFormState extends ConsumerState<RiderForm> with RiderValidator {
                   validator: (value) => validateAlias(
                     value: value,
                     maxLengthMessage: strings.AliasMaxLength(
-                      Member.nameAndAliasMaxLength,
+                      Rider.nameAndAliasMaxLength,
                     ),
                     illegalCharachterMessage: strings.AliasIllegalCharacters,
                     isBlankMessage: strings.AliasBlank,
@@ -323,7 +323,7 @@ class _RiderFormState extends ConsumerState<RiderForm> with RiderValidator {
                         focusNode: _firstNameFocusNode,
                         textInputAction: TextInputAction.next,
                         controller: _firstNameController,
-                        maxLength: Member.nameAndAliasMaxLength,
+                        maxLength: Rider.nameAndAliasMaxLength,
                         placeholder: strings.FirstName,
                         keyboardType: TextInputType.text,
                         onChanged: _resetSubmit,
@@ -331,7 +331,7 @@ class _RiderFormState extends ConsumerState<RiderForm> with RiderValidator {
                           value: value,
                           requiredMessage: strings.FirstNameRequired,
                           maxLengthMessage: strings.FirstNameMaxLength(
-                            Member.nameAndAliasMaxLength,
+                            Rider.nameAndAliasMaxLength,
                           ),
                           illegalCharachterMessage:
                               strings.FirstNameIllegalCharacters,
@@ -344,7 +344,7 @@ class _RiderFormState extends ConsumerState<RiderForm> with RiderValidator {
                         focusNode: _lastNameFocusNode,
                         textInputAction: TextInputAction.next,
                         controller: _lastNameController,
-                        maxLength: Member.nameAndAliasMaxLength,
+                        maxLength: Rider.nameAndAliasMaxLength,
                         placeholder: strings.LastName,
                         keyboardType: TextInputType.text,
                         onChanged: _resetSubmit,
@@ -352,7 +352,7 @@ class _RiderFormState extends ConsumerState<RiderForm> with RiderValidator {
                           value: value,
                           requiredMessage: strings.LastNameRequired,
                           maxLengthMessage: strings.LastNameMaxLength(
-                            Member.nameAndAliasMaxLength,
+                            Rider.nameAndAliasMaxLength,
                           ),
                           illegalCharachterMessage:
                               strings.LastNameIllegalCharacters,
@@ -365,13 +365,13 @@ class _RiderFormState extends ConsumerState<RiderForm> with RiderValidator {
                         textInputAction: TextInputAction.done,
                         controller: _aliasController,
                         keyboardType: TextInputType.text,
-                        maxLength: Member.nameAndAliasMaxLength,
+                        maxLength: Rider.nameAndAliasMaxLength,
                         placeholder: strings.Alias,
                         onChanged: _resetSubmit,
                         validator: (value) => validateAlias(
                           value: value,
                           maxLengthMessage: strings.AliasMaxLength(
-                            Member.nameAndAliasMaxLength,
+                            Rider.nameAndAliasMaxLength,
                           ),
                           illegalCharachterMessage:
                               strings.AliasIllegalCharacters,


### PR DESCRIPTION
This PR renames the `Member` class to `Rider`.
It also fixes comments in `rider.dart` still referring to 'member'.

Part of #256 