### PR TITLE
Fix usages in scanning delegate, settings model & manual selection list

### DIFF
--- a/lib/widgets/pages/member_list/member_list_page.dart
+++ b/lib/widgets/pages/member_list/member_list_page.dart
@@ -46,10 +46,10 @@ class MemberListPageState extends ConsumerState<MemberListPage> {
       return list;
     }
 
-    return list.where((member) {
-      final firstName = member.firstName.toLowerCase();
-      final lastName = member.lastName.toLowerCase();
-      final alias = member.alias.toLowerCase();
+    return list.where((rider) {
+      final firstName = rider.firstName.toLowerCase();
+      final lastName = rider.lastName.toLowerCase();
+      final alias = rider.alias.toLowerCase();
 
       if (firstName.contains(query) || lastName.contains(query)) {
         return true;

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list.dart
@@ -89,7 +89,7 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
 
   /// Sort the active members on their name and alias.
   Future<List<Rider>> _sortActiveMembers() async {
-    final items = widget.delegate.activeMembers;
+    final items = widget.delegate.activeRiders;
 
     items.sort((Rider m1, Rider m2) => m1.compareTo(m2));
 
@@ -100,7 +100,7 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
   void initState() {
     super.initState();
 
-    if (widget.delegate.hasActiveMembers) {
+    if (widget.delegate.hasActiveRiders) {
       _activeMembersFuture = _sortActiveMembers();
     }
   }
@@ -177,7 +177,7 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
 
   @override
   Widget build(BuildContext context) {
-    if (widget.delegate.hasActiveMembers) {
+    if (widget.delegate.hasActiveRiders) {
       return FutureBuilder<List<Rider>>(
         future: _activeMembersFuture,
         builder: (context, snapshot) {

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list.dart
@@ -16,7 +16,7 @@ import 'package:weforza/widgets/pages/ride_attendee_scanning_page/manual_selecti
 import 'package:weforza/widgets/platform/platform_aware_loading_indicator.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 
-/// This widget represents the list of active members that is shown
+/// This widget represents the list of active riders that is shown
 /// after the device scan has ended,
 /// and any conflicts with unresolved owners have been corrected.
 class ManualSelectionList extends StatefulWidget {
@@ -25,7 +25,7 @@ class ManualSelectionList extends StatefulWidget {
     super.key,
   });
 
-  /// The delegate that manages the list of active members.
+  /// The delegate that manages the list of active riders.
   final RideAttendeeScanningDelegate delegate;
 
   @override
@@ -33,13 +33,13 @@ class ManualSelectionList extends StatefulWidget {
 }
 
 class _ManualSelectionListState extends State<ManualSelectionList> {
-  Future<List<Rider>>? _activeMembersFuture;
+  Future<List<Rider>>? _activeRidersFuture;
 
   final _filtersController = ManualSelectionFilterDelegate();
 
   Future<void>? _saveFuture;
 
-  List<Rider> _filterActiveMembers(
+  List<Rider> _filterActiveRiders(
     List<Rider> items,
     ManualSelectionFilterOptions filters,
   ) {
@@ -87,8 +87,8 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
     );
   }
 
-  /// Sort the active members on their name and alias.
-  Future<List<Rider>> _sortActiveMembers() async {
+  /// Sort the active riders on their name and alias.
+  Future<List<Rider>> _sortActiveRiders() async {
     final items = widget.delegate.activeRiders;
 
     items.sort((Rider m1, Rider m2) => m1.compareTo(m2));
@@ -101,11 +101,11 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
     super.initState();
 
     if (widget.delegate.hasActiveRiders) {
-      _activeMembersFuture = _sortActiveMembers();
+      _activeRidersFuture = _sortActiveRiders();
     }
   }
 
-  Widget _buildActiveMembersList(BuildContext context, List<Rider> items) {
+  Widget _buildActiveRidersList(BuildContext context, List<Rider> items) {
     final translator = S.of(context);
 
     return FocusAbsorber(
@@ -140,7 +140,7 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
               initialData: _filtersController.currentFilters,
               stream: _filtersController.filters,
               builder: (context, snapshot) {
-                final results = _filterActiveMembers(items, snapshot.data!);
+                final results = _filterActiveRiders(items, snapshot.data!);
 
                 if (results.isEmpty) {
                   return const RiderSearchFilterEmpty();
@@ -179,14 +179,14 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
   Widget build(BuildContext context) {
     if (widget.delegate.hasActiveRiders) {
       return FutureBuilder<List<Rider>>(
-        future: _activeMembersFuture,
+        future: _activeRidersFuture,
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.done) {
             if (snapshot.hasError) {
               return const Center(child: GenericScanError());
             }
 
-            return _buildActiveMembersList(context, snapshot.data ?? []);
+            return _buildActiveRidersList(context, snapshot.data ?? []);
           }
 
           return const Center(child: PlatformAwareLoadingIndicator());

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_item.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_item.dart
@@ -77,7 +77,7 @@ class _ManualSelectionListItemState
         // If the search bar still has focus, unfocus it first.
         FocusScope.of(context).unfocus();
 
-        final accepted = await widget.delegate.toggleSelectionForActiveMember(
+        final accepted = await widget.delegate.toggleSelectionForActiveRider(
           ScannedRideAttendee(uuid: widget.item.uuid, isScanned: isScanned),
           () async {
             final result = await showWeforzaDialog<bool>(

--- a/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_page.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_page.dart
@@ -39,7 +39,7 @@ class RideAttendeeScanningPageState
 
     delegate = RideAttendeeScanningDelegate(
       deviceRepository: ref.read(deviceRepositoryProvider),
-      memberRepository: ref.read(riderRepositoryProvider),
+      riderRepository: ref.read(riderRepositoryProvider),
       ride: ref.read(selectedRideProvider)!,
       rideRepository: ref.read(rideRepositoryProvider),
       scanner: ref.read(bluetoothProvider),

--- a/lib/widgets/pages/ride_details/ride_details_attendees/ride_details_attendees_list.dart
+++ b/lib/widgets/pages/ride_details/ride_details_attendees/ride_details_attendees_list.dart
@@ -29,12 +29,12 @@ class RideDetailsAttendeesList extends ConsumerWidget {
             Expanded(
               child: ListView.builder(
                 itemBuilder: (context, index) {
-                  final member = attendees[index];
+                  final attendee = attendees[index];
 
                   return RideDetailsAttendeesListItem(
-                    firstName: member.firstName,
-                    lastName: member.lastName,
-                    alias: member.alias,
+                    firstName: attendee.firstName,
+                    lastName: attendee.lastName,
+                    alias: attendee.alias,
                   );
                 },
                 itemCount: attendees.length,

--- a/lib/widgets/pages/settings/settings_page.dart
+++ b/lib/widgets/pages/settings/settings_page.dart
@@ -110,7 +110,7 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
           padding: EdgeInsets.only(left: 12, right: 12, top: 12),
           child: ExcludedTermsListFooter(),
         ),
-        memberListFilter: Padding(
+        riderListFilter: Padding(
           padding: const EdgeInsets.fromLTRB(12, 16, 12, 8),
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -239,7 +239,7 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
           padding: EdgeInsets.fromLTRB(20, 10, 20, 0),
           child: ExcludedTermsListFooter(),
         ),
-        memberListFilter: CupertinoFormSection.insetGrouped(
+        riderListFilter: CupertinoFormSection.insetGrouped(
           header: Text(translator.Riders.toUpperCase()),
           footer: Text(translator.RidersListFilterDescription),
           children: [

--- a/lib/widgets/pages/settings/settings_page_scroll_view.dart
+++ b/lib/widgets/pages/settings/settings_page_scroll_view.dart
@@ -6,7 +6,7 @@ class SettingsPageScrollView extends StatelessWidget {
   const SettingsPageScrollView({
     required this.excludedTermsList,
     required this.excludedTermsListFooter,
-    required this.memberListFilter,
+    required this.riderListFilter,
     required this.resetRideCalendarButton,
     required this.scanDurationOption,
     required this.version,
@@ -24,8 +24,8 @@ class SettingsPageScrollView extends StatelessWidget {
   /// The widget that represents the header for the excluded terms list.
   final Widget? excludedTermsListHeader;
 
-  /// The widget that represents the member list filter.
-  final Widget memberListFilter;
+  /// The widget that represents the rider list filter.
+  final Widget riderListFilter;
 
   /// The sliver navigation bar that is placed first in the scrollview.
   final Widget? navigationBar;
@@ -46,7 +46,7 @@ class SettingsPageScrollView extends StatelessWidget {
         if (navigationBar != null) navigationBar!,
         SliverList(
           delegate: SliverChildListDelegate.fixed([
-            memberListFilter,
+            riderListFilter,
             scanDurationOption,
             if (excludedTermsListHeader != null) excludedTermsListHeader!,
           ]),


### PR DESCRIPTION
This PR renames the usages in the scanning delegate, the settings class filter option and in the manual selection widget.

Part of #256 