### PR TITLE
Clean up rider detail widgets

### DIFF
--- a/lib/widgets/common/rider_attending_count.dart
+++ b/lib/widgets/common/rider_attending_count.dart
@@ -9,7 +9,7 @@ import 'package:weforza/widgets/platform/platform_aware_loading_indicator.dart';
 /// The provider for the attending count of a single rider list item
 /// is an `autoDispose` provider as there might be many items in the list,
 /// that get built nd destroyed.
-final _memberAttendingCount =
+final _riderAttendingCount =
     FutureProvider.autoDispose.family<int, String>((ref, uuid) {
   final repository = ref.read(riderRepositoryProvider);
 
@@ -17,9 +17,9 @@ final _memberAttendingCount =
 });
 
 /// This widget represents the base attending count widget
-/// that is used by [MemberListItemAttendingCount] and [SelectedMemberAttendingCount].
-class _MemberAttendingCount extends StatelessWidget {
-  const _MemberAttendingCount(this.value);
+/// that is used by [RiderListItemAttendingCount] and [SelectedRiderAttendingCount].
+class _RiderAttendingCount extends StatelessWidget {
+  const _RiderAttendingCount(this.value);
 
   final AsyncValue<int?> value;
 
@@ -73,30 +73,30 @@ class _MemberAttendingCount extends StatelessWidget {
 }
 
 /// This widget represents the attending count for a rider list item.
-class MemberListItemAttendingCount extends ConsumerWidget {
-  const MemberListItemAttendingCount({
-    required this.member,
+class RiderListItemAttendingCount extends ConsumerWidget {
+  const RiderListItemAttendingCount({
+    required this.rider,
     super.key,
   });
 
-  final Rider member;
+  final Rider rider;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final value = ref.watch(_memberAttendingCount(member.uuid));
+    final value = ref.watch(_riderAttendingCount(rider.uuid));
 
-    return _MemberAttendingCount(value);
+    return _RiderAttendingCount(value);
   }
 }
 
 /// This widget represents the attending count for the selected rider.
-class SelectedMemberAttendingCount extends ConsumerWidget {
-  const SelectedMemberAttendingCount({super.key});
+class SelectedRiderAttendingCount extends ConsumerWidget {
+  const SelectedRiderAttendingCount({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final value = ref.watch(selectedRiderAttendingCountProvider);
 
-    return _MemberAttendingCount(value);
+    return _RiderAttendingCount(value);
   }
 }

--- a/lib/widgets/common/rider_name_and_alias.dart
+++ b/lib/widgets/common/rider_name_and_alias.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
-/// This widget displays the first name, alias and last name of a member.
-class MemberNameAndAlias extends StatelessWidget {
-  const MemberNameAndAlias.singleLine({
+/// This widget displays the first name, alias and last name of a rider.
+class RiderNameAndAlias extends StatelessWidget {
+  const RiderNameAndAlias.singleLine({
     required this.alias,
     required this.firstName,
     required this.lastName,
@@ -13,7 +13,7 @@ class MemberNameAndAlias extends StatelessWidget {
         firstLineStyle = style,
         secondLineStyle = null;
 
-  const MemberNameAndAlias.twoLines({
+  const RiderNameAndAlias.twoLines({
     required this.alias,
     required this.firstLineStyle,
     required this.firstName,
@@ -28,8 +28,12 @@ class MemberNameAndAlias extends StatelessWidget {
 
   /// The style for the text on the first line.
   ///
-  /// If [isTwoLine] is true, this is the style for the first name and the alias.
-  /// Otherwise this is the style for the first name, alias and last name.
+  /// If the name of the rider is displayed on a single line,
+  /// this is the style for the text.
+  ///
+  /// If the name of the rider is displayed on two lines,
+  /// this is the style for the first name and the alias,
+  /// which are displayed on the first line.
   final TextStyle firstLineStyle;
 
   /// The first name to display.

--- a/lib/widgets/pages/home_page.dart
+++ b/lib/widgets/pages/home_page.dart
@@ -7,7 +7,7 @@ import 'package:weforza/widgets/pages/settings/settings_page.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 
 /// The home page of the application.
-/// This page provides access to the ride list page, the member list page
+/// This page provides access to the ride list page, the riders list page
 /// and the settings page.
 ///
 /// By default the ride list page is shown.
@@ -55,7 +55,7 @@ class _HomePageState extends State<HomePage>
       controller: _pageController,
       onPageChanged: (page) {
         // When switching pages in the page view, the old page gives up focus.
-        // The member list page has a search field,
+        // The riders list page has a search field,
         // and the settings page has several text fields.
         // Only the ride list page has nothing that can have keyboard focus.
         if (_selectedIndex != 0) {

--- a/lib/widgets/pages/member_details/member_details_page.dart
+++ b/lib/widgets/pages/member_details/member_details_page.dart
@@ -10,7 +10,7 @@ import 'package:weforza/widgets/dialogs/dialogs.dart';
 import 'package:weforza/widgets/pages/member_details/member_active_toggle.dart';
 import 'package:weforza/widgets/pages/member_details/member_devices_list/member_devices_list.dart';
 import 'package:weforza/widgets/pages/member_details/member_name.dart';
-import 'package:weforza/widgets/pages/member_details/member_profile_image.dart';
+import 'package:weforza/widgets/pages/member_details/rider_profile_image.dart';
 import 'package:weforza/widgets/pages/rider_form.dart';
 import 'package:weforza/widgets/platform/cupertino_icon_button.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
@@ -132,7 +132,7 @@ class MemberDetailsPage extends StatelessWidget {
           children: const [
             Padding(
               padding: EdgeInsets.all(8),
-              child: MemberProfileImage(),
+              child: RiderProfileImage(),
             ),
             Expanded(child: MemberName()),
           ],

--- a/lib/widgets/pages/member_details/member_details_page.dart
+++ b/lib/widgets/pages/member_details/member_details_page.dart
@@ -4,7 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/model/rider/rider.dart';
 import 'package:weforza/riverpod/rider/selected_rider_provider.dart';
-import 'package:weforza/widgets/common/member_attending_count.dart';
+import 'package:weforza/widgets/common/rider_attending_count.dart';
 import 'package:weforza/widgets/dialogs/delete_rider_dialog.dart';
 import 'package:weforza/widgets/dialogs/dialogs.dart';
 import 'package:weforza/widgets/pages/member_details/member_active_toggle.dart';
@@ -141,7 +141,7 @@ class MemberDetailsPage extends StatelessWidget {
           padding: const EdgeInsets.only(top: 4, left: 8, right: 8),
           child: Row(
             children: const [
-              SelectedMemberAttendingCount(),
+              SelectedRiderAttendingCount(),
               Expanded(child: Center()),
               MemberActiveToggle(),
             ],

--- a/lib/widgets/pages/member_details/member_details_page.dart
+++ b/lib/widgets/pages/member_details/member_details_page.dart
@@ -7,8 +7,8 @@ import 'package:weforza/riverpod/rider/selected_rider_provider.dart';
 import 'package:weforza/widgets/common/rider_attending_count.dart';
 import 'package:weforza/widgets/dialogs/delete_rider_dialog.dart';
 import 'package:weforza/widgets/dialogs/dialogs.dart';
+import 'package:weforza/widgets/pages/member_details/member_devices_list/rider_devices_list.dart';
 import 'package:weforza/widgets/pages/member_details/rider_active_toggle.dart';
-import 'package:weforza/widgets/pages/member_details/member_devices_list/member_devices_list.dart';
 import 'package:weforza/widgets/pages/member_details/rider_name.dart';
 import 'package:weforza/widgets/pages/member_details/rider_profile_image.dart';
 import 'package:weforza/widgets/pages/rider_form.dart';
@@ -74,7 +74,7 @@ class MemberDetailsPage extends StatelessWidget {
     return Column(
       children: <Widget>[
         _buildMemberInfoSection(context),
-        const Expanded(child: MemberDevicesList()),
+        const Expanded(child: RiderDevicesList()),
       ],
     );
   }

--- a/lib/widgets/pages/member_details/member_details_page.dart
+++ b/lib/widgets/pages/member_details/member_details_page.dart
@@ -9,7 +9,7 @@ import 'package:weforza/widgets/dialogs/delete_rider_dialog.dart';
 import 'package:weforza/widgets/dialogs/dialogs.dart';
 import 'package:weforza/widgets/pages/member_details/member_active_toggle.dart';
 import 'package:weforza/widgets/pages/member_details/member_devices_list/member_devices_list.dart';
-import 'package:weforza/widgets/pages/member_details/member_name.dart';
+import 'package:weforza/widgets/pages/member_details/rider_name.dart';
 import 'package:weforza/widgets/pages/member_details/rider_profile_image.dart';
 import 'package:weforza/widgets/pages/rider_form.dart';
 import 'package:weforza/widgets/platform/cupertino_icon_button.dart';
@@ -134,7 +134,7 @@ class MemberDetailsPage extends StatelessWidget {
               padding: EdgeInsets.all(8),
               child: RiderProfileImage(),
             ),
-            Expanded(child: MemberName()),
+            Expanded(child: RiderName()),
           ],
         ),
         Padding(

--- a/lib/widgets/pages/member_details/member_details_page.dart
+++ b/lib/widgets/pages/member_details/member_details_page.dart
@@ -7,7 +7,7 @@ import 'package:weforza/riverpod/rider/selected_rider_provider.dart';
 import 'package:weforza/widgets/common/rider_attending_count.dart';
 import 'package:weforza/widgets/dialogs/delete_rider_dialog.dart';
 import 'package:weforza/widgets/dialogs/dialogs.dart';
-import 'package:weforza/widgets/pages/member_details/member_active_toggle.dart';
+import 'package:weforza/widgets/pages/member_details/rider_active_toggle.dart';
 import 'package:weforza/widgets/pages/member_details/member_devices_list/member_devices_list.dart';
 import 'package:weforza/widgets/pages/member_details/rider_name.dart';
 import 'package:weforza/widgets/pages/member_details/rider_profile_image.dart';
@@ -143,7 +143,7 @@ class MemberDetailsPage extends StatelessWidget {
             children: const [
               SelectedRiderAttendingCount(),
               Expanded(child: Center()),
-              MemberActiveToggle(),
+              RiderActiveToggle(),
             ],
           ),
         )

--- a/lib/widgets/pages/member_details/member_devices_list/rider_devices_list.dart
+++ b/lib/widgets/pages/member_details/member_devices_list/rider_devices_list.dart
@@ -8,20 +8,20 @@ import 'package:weforza/riverpod/rider/selected_rider_provider.dart';
 import 'package:weforza/widgets/common/generic_error.dart';
 import 'package:weforza/widgets/pages/device_form.dart';
 import 'package:weforza/widgets/pages/member_details/member_devices_list/delete_device_button.dart';
-import 'package:weforza/widgets/pages/member_details/member_devices_list/member_devices_list_empty.dart';
-import 'package:weforza/widgets/pages/member_details/member_devices_list/member_devices_list_header.dart';
-import 'package:weforza/widgets/pages/member_details/member_devices_list/member_devices_list_item.dart';
+import 'package:weforza/widgets/pages/member_details/member_devices_list/rider_devices_list_empty.dart';
+import 'package:weforza/widgets/pages/member_details/member_devices_list/rider_devices_list_header.dart';
+import 'package:weforza/widgets/pages/member_details/member_devices_list/rider_devices_list_item.dart';
 import 'package:weforza/widgets/platform/platform_aware_loading_indicator.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 
-class MemberDevicesList extends ConsumerStatefulWidget {
-  const MemberDevicesList({super.key});
+class RiderDevicesList extends ConsumerStatefulWidget {
+  const RiderDevicesList({super.key});
 
   @override
-  MemberDevicesListState createState() => MemberDevicesListState();
+  ConsumerState<RiderDevicesList> createState() => _RiderDevicesListState();
 }
 
-class MemberDevicesListState extends ConsumerState<MemberDevicesList> {
+class _RiderDevicesListState extends ConsumerState<RiderDevicesList> {
   void onAddDevicePressed(BuildContext context, String ownerUuid) {
     Navigator.of(context).push<void>(
       MaterialPageRoute(
@@ -37,7 +37,7 @@ class MemberDevicesListState extends ConsumerState<MemberDevicesList> {
     return devicesList.when(
       data: (devices) {
         if (devices.isEmpty) {
-          return const MemberDevicesListEmpty();
+          return const RiderDevicesListEmpty();
         }
 
         return _buildDevicesList(context, devices);
@@ -51,13 +51,13 @@ class MemberDevicesListState extends ConsumerState<MemberDevicesList> {
     return SafeArea(
       child: Column(
         children: <Widget>[
-          const MemberDevicesListHeader(),
+          const RiderDevicesListHeader(),
           Expanded(
             child: ListView.builder(
               itemBuilder: (context, index) {
                 final device = devices[index];
 
-                return MemberDevicesListItem(
+                return RiderDevicesListItem(
                   device: device,
                   deleteDeviceButton: DeleteDeviceButton(index: index),
                 );

--- a/lib/widgets/pages/member_details/member_devices_list/rider_devices_list_empty.dart
+++ b/lib/widgets/pages/member_details/member_devices_list/rider_devices_list_empty.dart
@@ -8,8 +8,8 @@ import 'package:weforza/widgets/platform/platform_aware_icon.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 
 /// This widget represents the empty rider devices list.
-class MemberDevicesListEmpty extends StatelessWidget {
-  const MemberDevicesListEmpty({super.key});
+class RiderDevicesListEmpty extends StatelessWidget {
+  const RiderDevicesListEmpty({super.key});
 
   void onAddDevicePressed(BuildContext context, String ownerUuid) {
     Navigator.of(context).push(

--- a/lib/widgets/pages/member_details/member_devices_list/rider_devices_list_header.dart
+++ b/lib/widgets/pages/member_details/member_devices_list/rider_devices_list_header.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 
-class MemberDevicesListHeader extends StatelessWidget {
-  const MemberDevicesListHeader({super.key});
+class RiderDevicesListHeader extends StatelessWidget {
+  const RiderDevicesListHeader({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/pages/member_details/member_devices_list/rider_devices_list_item.dart
+++ b/lib/widgets/pages/member_details/member_devices_list/rider_devices_list_item.dart
@@ -8,8 +8,8 @@ import 'package:weforza/widgets/pages/device_form.dart';
 import 'package:weforza/widgets/platform/cupertino_icon_button.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 
-class MemberDevicesListItem extends StatelessWidget {
-  const MemberDevicesListItem({
+class RiderDevicesListItem extends StatelessWidget {
+  const RiderDevicesListItem({
     required this.deleteDeviceButton,
     required this.device,
     super.key,

--- a/lib/widgets/pages/member_details/rider_active_toggle.dart
+++ b/lib/widgets/pages/member_details/rider_active_toggle.dart
@@ -6,8 +6,8 @@ import 'package:weforza/riverpod/rider/selected_rider_provider.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 
 /// This widget resembles the toggle switch for the 'active' state of a rider.
-class MemberActiveToggle extends StatelessWidget {
-  const MemberActiveToggle({super.key});
+class RiderActiveToggle extends StatelessWidget {
+  const RiderActiveToggle({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/pages/member_details/rider_name.dart
+++ b/lib/widgets/pages/member_details/rider_name.dart
@@ -3,8 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/riverpod/rider/selected_rider_provider.dart';
 import 'package:weforza/widgets/theme.dart';
 
-class MemberName extends ConsumerWidget {
-  const MemberName({super.key});
+class RiderName extends ConsumerWidget {
+  const RiderName({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/widgets/pages/member_details/rider_profile_image.dart
+++ b/lib/widgets/pages/member_details/rider_profile_image.dart
@@ -4,8 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/riverpod/rider/selected_rider_provider.dart';
 import 'package:weforza/widgets/custom/profile_image/profile_image.dart';
 
-class MemberProfileImage extends ConsumerWidget {
-  const MemberProfileImage({super.key});
+class RiderProfileImage extends ConsumerWidget {
+  const RiderProfileImage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/widgets/pages/member_list/member_list_item.dart
+++ b/lib/widgets/pages/member_list/member_list_item.dart
@@ -4,8 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/model/rider/rider.dart';
 import 'package:weforza/riverpod/rider/selected_rider_devices_provider.dart';
 import 'package:weforza/riverpod/rider/selected_rider_provider.dart';
-import 'package:weforza/widgets/common/member_attending_count.dart';
 import 'package:weforza/widgets/common/member_name_and_alias.dart';
+import 'package:weforza/widgets/common/rider_attending_count.dart';
 import 'package:weforza/widgets/custom/profile_image/profile_image.dart';
 import 'package:weforza/widgets/theme.dart';
 
@@ -60,7 +60,7 @@ class MemberListItem extends ConsumerWidget {
             ),
             Padding(
               padding: const EdgeInsets.only(left: 4),
-              child: MemberListItemAttendingCount(member: member),
+              child: RiderListItemAttendingCount(rider: member),
             ),
           ],
         ),

--- a/lib/widgets/pages/member_list/member_list_item.dart
+++ b/lib/widgets/pages/member_list/member_list_item.dart
@@ -4,8 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/model/rider/rider.dart';
 import 'package:weforza/riverpod/rider/selected_rider_devices_provider.dart';
 import 'package:weforza/riverpod/rider/selected_rider_provider.dart';
-import 'package:weforza/widgets/common/member_name_and_alias.dart';
 import 'package:weforza/widgets/common/rider_attending_count.dart';
+import 'package:weforza/widgets/common/rider_name_and_alias.dart';
 import 'package:weforza/widgets/custom/profile_image/profile_image.dart';
 import 'package:weforza/widgets/theme.dart';
 
@@ -50,7 +50,7 @@ class MemberListItem extends ConsumerWidget {
               ),
             ),
             Expanded(
-              child: MemberNameAndAlias.twoLines(
+              child: RiderNameAndAlias.twoLines(
                 alias: member.alias,
                 firstLineStyle: textTheme.firstNameStyle,
                 firstName: member.firstName,

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_item.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_item.dart
@@ -4,7 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart';
 import 'package:weforza/model/ride_attendee_scanning/scanned_ride_attendee.dart';
 import 'package:weforza/model/rider/rider.dart';
-import 'package:weforza/widgets/common/member_name_and_alias.dart';
+import 'package:weforza/widgets/common/rider_name_and_alias.dart';
 import 'package:weforza/widgets/custom/profile_image/profile_image.dart';
 import 'package:weforza/widgets/dialogs/dialogs.dart';
 import 'package:weforza/widgets/dialogs/unselect_scanned_rider_dialog.dart';
@@ -108,7 +108,7 @@ class _ManualSelectionListItemState
               ),
             ),
             Expanded(
-              child: MemberNameAndAlias.twoLines(
+              child: RiderNameAndAlias.twoLines(
                 alias: widget.item.alias,
                 firstLineStyle: firstNameStyle,
                 firstName: widget.item.firstName,

--- a/lib/widgets/pages/ride_attendee_scanning_page/scan_results_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/scan_results_list.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart';
 import 'package:weforza/model/ride_attendee_scanning/scanned_device.dart';
-import 'package:weforza/widgets/common/member_name_and_alias.dart';
+import 'package:weforza/widgets/common/rider_name_and_alias.dart';
 import 'package:weforza/widgets/pages/ride_attendee_scanning_page/scan_button.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 
@@ -145,7 +145,7 @@ class _ScanResultsListItem extends StatelessWidget {
           padding: const EdgeInsets.only(right: 4),
           child: Icon(icon, color: textStyle.color),
         ),
-        MemberNameAndAlias.singleLine(
+        RiderNameAndAlias.singleLine(
           alias: owner.alias,
           firstName: owner.firstName,
           lastName: owner.lastName,

--- a/lib/widgets/pages/ride_attendee_scanning_page/unresolved_owners_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/unresolved_owners_list.dart
@@ -4,7 +4,7 @@ import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart';
 import 'package:weforza/model/ride_attendee_scanning/scanned_ride_attendee.dart';
 import 'package:weforza/model/rider/rider.dart';
-import 'package:weforza/widgets/common/member_name_and_alias.dart';
+import 'package:weforza/widgets/common/rider_name_and_alias.dart';
 import 'package:weforza/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart';
 import 'package:weforza/widgets/pages/ride_attendee_scanning_page/scan_button.dart';
 import 'package:weforza/widgets/platform/platform_aware_loading_indicator.dart';
@@ -163,7 +163,7 @@ class _UnresolvedOwnersListItemState extends State<_UnresolvedOwnersListItem> {
 
     Widget child = Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      child: MemberNameAndAlias.twoLines(
+      child: RiderNameAndAlias.twoLines(
         alias: widget.item.alias,
         firstLineStyle: firstNameStyle,
         firstName: widget.item.firstName,

--- a/lib/widgets/pages/ride_details/ride_details_attendees/ride_details_attendees_list_item.dart
+++ b/lib/widgets/pages/ride_details/ride_details_attendees/ride_details_attendees_list_item.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/widgets.dart';
-import 'package:weforza/widgets/common/member_name_and_alias.dart';
+import 'package:weforza/widgets/common/rider_name_and_alias.dart';
 import 'package:weforza/widgets/theme.dart';
 
 class RideDetailsAttendeesListItem extends StatelessWidget {
@@ -21,7 +21,7 @@ class RideDetailsAttendeesListItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(4),
-      child: MemberNameAndAlias.singleLine(
+      child: RiderNameAndAlias.singleLine(
         firstName: firstName,
         lastName: lastName,
         alias: alias,


### PR DESCRIPTION
This PR renames usages in:
- the rider attending count widget
- the rider name & profile image widgets
- the rider active toggle
- the rider devices list widgets

Part of #256 