### PR TITLE
iOS 16 support

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3,14 +3,14 @@ PODS:
     - Flutter
   - device_info_plus (0.0.1):
     - Flutter
-  - DKImagePickerController/Core (4.3.2):
+  - DKImagePickerController/Core (4.3.4):
     - DKImagePickerController/ImageDataManager
     - DKImagePickerController/Resource
-  - DKImagePickerController/ImageDataManager (4.3.2)
-  - DKImagePickerController/PhotoGallery (4.3.2):
+  - DKImagePickerController/ImageDataManager (4.3.4)
+  - DKImagePickerController/PhotoGallery (4.3.4):
     - DKImagePickerController/Core
     - DKPhotoGallery
-  - DKImagePickerController/Resource (4.3.2)
+  - DKImagePickerController/Resource (4.3.4)
   - DKPhotoGallery (0.0.17):
     - DKPhotoGallery/Core (= 0.0.17)
     - DKPhotoGallery/Model (= 0.0.17)
@@ -55,10 +55,10 @@ PODS:
   - permission_handler_apple (9.0.4):
     - Flutter
   - Protobuf (3.19.4)
-  - SDWebImage (5.8.1):
-    - SDWebImage/Core (= 5.8.1)
-  - SDWebImage/Core (5.8.1)
-  - SwiftyGif (5.3.0)
+  - SDWebImage (5.15.0):
+    - SDWebImage/Core (= 5.15.0)
+  - SDWebImage/Core (5.15.0)
+  - SwiftyGif (5.4.4)
 
 DEPENDENCIES:
   - app_settings (from `.symlinks/plugins/app_settings/ios`)
@@ -105,9 +105,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   app_settings: d103828c9f5d515c4df9ee754dabd443f7cedcf3
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
-  DKImagePickerController: b5eb7f7a388e4643264105d648d01f727110fc3d
+  DKImagePickerController: b512c28220a2b8ac7419f21c491fc8534b7601ac
   DKPhotoGallery: fdfad5125a9fdda9cc57df834d49df790dbb4179
-  file_picker: 817ab1d8cd2da9d2da412a417162deee3500fc95
+  file_picker: ce3938a0df3cc1ef404671531facef740d03f920
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_blue_plus: 6787777145d615de01828f3a9fa423c3c702f0b3
   image_picker_ios: b786a5dcf033a8336a657191401bfdf12017dabb
@@ -116,8 +116,8 @@ SPEC CHECKSUMS:
   path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
   permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
   Protobuf: 235750e4696ff59fb07d949a9dbbc92b3c0700fe
-  SDWebImage: e3eae2eda88578db0685a0c88597fdadd9433f05
-  SwiftyGif: e466e86c660d343357ab944a819a101c4127cb40
+  SDWebImage: 9bec4c5cdd9579e1f57104735ee0c37df274d593
+  SwiftyGif: 93a1cc87bf3a51916001cf8f3d63835fb64c819f
 
 PODFILE CHECKSUM: b7946d30385ba0892e09d597375feb864f16cab6
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: ecf52f978e72763ede54a93271318bbbca65a2be2d9ff658ec8ca4ea3a23d7ef
+      sha256: d090ae03df98b0247b82e5928f44d1b959867049d18d73635e2e0bc3f49542b9
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.4"
+    version: "5.2.5"
   file_testing:
     dependency: "direct dev"
     description:
@@ -850,5 +850,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.0-444.1.beta <4.0.0"
+  dart: ">=2.19.0 <4.0.0"
   flutter: ">=3.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,7 @@ description: The WeForza App
 version: 1.0.0+1
 
 environment:
-  # TODO: bump dart to a stable release once the next Flutter stable release is available
-  sdk: ">=2.19.0-444.1.beta <3.0.0"
+  sdk: ">=2.19.0 <3.0.0"
 
 dependencies:
   # This package provides easy access to app settings.
@@ -36,7 +35,7 @@ dependencies:
   file: ^6.1.4
 
   # This package provides platform independent file picking.
-  file_picker: ^5.2.4
+  file_picker: ^5.2.5
 
   flutter:
     sdk: flutter


### PR DESCRIPTION
This PR updates the app so that it builds on iOS 16.2.

There was a build error due to XCode 14 no longer allowing something specific.
This was fixed by bumping DKImagePickerController to version `4.3.4` in the `Podfile.lock`.

Fixes #268 