### PR TITLE
iOS Release 1.0 - finishing touches

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,33 @@ If a new locale is added, a [full restart is required](https://github.com/flutte
 
 See also: https://docs.flutter.dev/development/accessibility-and-localization/internationalization
 
+#### Translating the iOS Information Property List file (Info.plist)
+
+The `Info.plist` file contains `NSUsageDescription` tags that should be translated.
+These contain the descriptions for system defined permission dialogs.
+The title and button labels are provided by the system and do not have to be translated.
+
+To translate the Info.plist file do the following:
+
+A) If the InfoPlist.strings file does not yet exist:
+
+- Create a new Resource file under `ios > Runner > Runner`
+- Select the inner `Runner` target
+- Right click and select `New File`
+- Select `Strings File` under the `Resource` category
+- Create the new file with the name `InfoPlist.strings`
+- Add the baseline translations (usually in English) in this file using the format `Key="Translation";`
+- Back in XCode, select the `InfoPlist.strings` file
+- Press the `Localise` button on the right
+- Select the languages that the `InfoPlist.strings` file should be localised in
+- Add the translations to the newly created `InfoPlist.strings` variants (one per selected language)
+
+b) If the InfoPlist.strings file does exist:
+
+- Select the `InfoPlist.strings` file
+- Add the desired languages that should have their `InfoPlist.strings` variants added
+- Add the translations to the newly created `InfoPlist.strings` variants (one per selected language)
+
 ### IOS on device testing
 
 Before runing the app on a real IOS device, this checklist should be performed.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ Before runing the app on a real IOS device, this checklist should be performed.
 ### IOS Deployment target version
 
 To bump the minimum iOS version for a project do the following:
-
-- Open the project in XCode and set the target OS version
+- Open the project in XCode
+- Set the iOS version under `Runner > General > Minimum Deployments > iOS`
+- In `ios/Flutter/AppFrameworkInfo.plist` set `MinimumOSVersion`
 - Update the `platform :ios, <version number>` section in the Podfile.
 - Ensure that the `flutter_additional_ios_build_settings(target)` section in ios/Podfile has set `IPHONEOS_DEPLOYMENT_TARGET`
 ```
@@ -40,7 +41,7 @@ To bump the minimum iOS version for a project do the following:
       installer.pods_project.targets.each do |target|
         flutter_additional_ios_build_settings(target)
         target.build_configurations.each do |config|
-          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '(version number, e.g. 14.4 for iOS 14.4)'
+          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '<version number>'
         end
       end
     end

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ Before runing the app on a real IOS device, this checklist should be performed.
 
 - Let XCode set up the device for development.
   * Check that the device is shown in XCode as the selected device.
-  * If it is shown as `untrusted`, trust the host machine from the device when connecting.
-    The device will ask this through a confirmation dialog.
-  * When prompted, register the device with XCode. Xcode will show a dialog for this.
+  * iOS 15 and lower: If the device is shown as `untrusted`, trust the host machine from the device when connecting.
+    The device will display a confirmation dialog. When prompted, register the device with XCode.
+  * iOS 16 and higher: On iOS 16 and higher Developer mode should be enabled on the device.
+  See https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device
 
 - If required, run `pods install` in the terminal. (preferably from the flutter project dir)
   Usually the Flutter tool does this automatically when building.

--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>10.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		43FE956E29A364160065D64D /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 43FE957029A364160065D64D /* InfoPlist.strings */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		9740EEB41CF90195004384FC /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 9740EEB21CF90195004384FC /* Debug.xcconfig */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
@@ -35,6 +36,8 @@
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		266AA9C099AAB9E56526F60A /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		43FE956F29A364160065D64D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		43FE957129A3643F0065D64D /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		674BD871350FD3DCD1C2C20D /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -122,6 +125,7 @@
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
+				43FE957029A364160065D64D /* InfoPlist.strings */,
 			);
 			path = Runner;
 			sourceTree = "<group>";
@@ -180,6 +184,7 @@
 			knownRegions = (
 				en,
 				Base,
+				nl,
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
@@ -197,6 +202,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
+				43FE956E29A364160065D64D /* InfoPlist.strings in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				9740EEB41CF90195004384FC /* Debug.xcconfig in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
@@ -316,6 +322,15 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXVariantGroup section */
+		43FE957029A364160065D64D /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				43FE956F29A364160065D64D /* en */,
+				43FE957129A3643F0065D64D /* nl */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
 		97C146FA1CF9000F007C117D /* Main.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -339,6 +354,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -422,6 +438,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -477,6 +494,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -169,7 +169,6 @@
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = 7NA6QL97A5;
 						LastSwiftMigration = 0910;
 					};
 				};

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -398,6 +398,8 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = WeForza;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.sports";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -407,6 +409,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = be.weforza.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -535,6 +538,8 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = WeForza;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.sports";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -544,6 +549,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = be.weforza.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -569,6 +575,8 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = WeForza;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.sports";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -578,6 +586,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = be.weforza.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -36,13 +36,13 @@
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<true/>
 	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>The application needs Bluetooth permissions to be able to scan for peripherals</string>
+	<string>The app uses Bluetooth to scan for Bluetooth peripherals in your immediate area.</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
-	<string>The application needs Bluetooth permissions to be able to scan for peripherals</string>
+	<string>The app uses Bluetooth to scan for Bluetooth peripherals in your immediate area.</string>
 	<key>NSCameraUsageDescription</key>
-	<string>The application needs access to the device camera, to allow users to take profile images with their device.</string>
+	<string>Allow access to your camera to take new profile pictures.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>The application needs access to the photo library, to allow users to select profile images.</string>
+	<string>Allow access to photos to select profile pictures from your photo library.</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UIFileSharingEnabled</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -35,10 +35,12 @@
 	<string>The application needs Bluetooth permissions to be able to scan for peripherals</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>The application needs Bluetooth permissions to be able to scan for peripherals</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>The application needs access to the photo library, to allow users to select profile images.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>The application needs access to the device camera, to allow users to take profile images with their device.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>The application needs access to the photo library, to allow users to select profile images.</string>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>
@@ -58,7 +60,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -36,13 +36,13 @@
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<true/>
 	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>The app uses Bluetooth to scan for Bluetooth peripherals in your immediate area.</string>
+	<string>The app uses Bluetooth to scan for Bluetooth-peripherals in your immediate area.</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
-	<string>The app uses Bluetooth to scan for Bluetooth peripherals in your immediate area.</string>
+	<string>The app uses Bluetooth to scan for Bluetooth-peripherals in your immediate area.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Allow access to your camera to take new profile pictures.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Allow access to photos to select profile pictures from your photo library.</string>
+	<string>Allow access to Photos to select profile pictures from your photo library.</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UIFileSharingEnabled</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -27,6 +27,10 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.sports</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>

--- a/ios/Runner/en.lproj/InfoPlist.strings
+++ b/ios/Runner/en.lproj/InfoPlist.strings
@@ -1,0 +1,10 @@
+/* 
+  InfoPlist.strings
+  Runner
+
+  Created by Navaron Bracke on 20/02/2023.
+*/
+NSBluetoothAlwaysUsageDescription = "The app uses Bluetooth to scan for Bluetooth-peripherals in your immediate area.";
+NSBluetoothPeripheralUsageDescription = "The app uses Bluetooth to scan for Bluetooth-peripherals in your immediate area.";
+NSCameraUsageDescription = "Allow access to your camera to take new profile pictures.";
+NSPhotoLibraryUsageDescription = "Allow access to Photos to select profile pictures from your photo library.";

--- a/ios/Runner/nl.lproj/InfoPlist.strings
+++ b/ios/Runner/nl.lproj/InfoPlist.strings
@@ -1,0 +1,10 @@
+/* 
+  InfoPlist.strings
+  Runner
+
+  Created by Navaron Bracke on 20/02/2023.
+*/
+NSBluetoothAlwaysUsageDescription = "De app gebruikt Bluetooth om te scannen naar Bluetooth-apparaten in je directe omgeving.";
+NSBluetoothPeripheralUsageDescription = "De app gebruikt Bluetooth om te scannen naar Bluetooth-apparaten in je directe omgeving.";
+NSCameraUsageDescription = "Geef toegang tot je camera om nieuwe profielfoto's te maken.";
+NSPhotoLibraryUsageDescription = "Geef toegang tot Foto's om profielfoto's uit je fotogalerij te selecteren.";


### PR DESCRIPTION
This PR adds the finishing touches before version 1.0 can be submitted to the App Store.

- Bump `MinOSVersion` to `12.0` in AppFramework.plist
- Translate Info.plist `NSUsageDescription` keys to English (base translation) and Dutch
- Set `public.app-category.sports` as the App Category
- Set `ITSAppUsesNonExemptEncryption` to `NO`
- Set Marketing Version to `1.0.0` in pbxproj
- Set DisplayName to `WeForza` in pbxproj