### PR TITLE
Dispose scanner hotfix

### DIFF
--- a/lib/bluetooth/bluetooth_device_scanner.dart
+++ b/lib/bluetooth/bluetooth_device_scanner.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:weforza/bluetooth/bluetooth_peripheral.dart';
 
@@ -53,8 +55,7 @@ class BluetoothDeviceScannerImpl implements BluetoothDeviceScanner {
 
   @override
   void dispose() {
-    stopScan().catchError((_) {
-      // If the scan could not be stopped, there is nothing that can be done.
-    });
+    // If the scan could not be stopped, there is nothing that can be done.
+    unawaited(stopScan().catchError((_) {}));
   }
 }

--- a/lib/bluetooth/mock_bluetooth_scanner.dart
+++ b/lib/bluetooth/mock_bluetooth_scanner.dart
@@ -7,7 +7,7 @@ class MockBluetoothScanner implements BluetoothDeviceScanner {
 
   final PublishSubject _stopScanPill = PublishSubject();
 
-  /// Build a fale scan results stream.
+  /// Build a fake scan results stream.
   Stream<BluetoothPeripheral> _buildScanResultsStream() async* {
     final duplicateOwner = BluetoothPeripheral(id: '1', deviceName: 'rudy1');
     final duplicateDevice = BluetoothPeripheral(
@@ -69,9 +69,7 @@ class MockBluetoothScanner implements BluetoothDeviceScanner {
       Rx.timer(null, Duration(seconds: scanDurationInSeconds)),
     ];
 
-    yield* _buildScanResultsStream()
-        .takeUntil(Rx.merge(killStreams))
-        .doOnDone(stopScan);
+    yield* _buildScanResultsStream().takeUntil(Rx.merge(killStreams)).doOnDone(stopScan);
   }
 
   @override

--- a/lib/riverpod/bluetooth_provider.dart
+++ b/lib/riverpod/bluetooth_provider.dart
@@ -1,9 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/bluetooth/bluetooth_device_scanner.dart';
 
-// TODO: regression test for scanning twice in a row not showing the scanning progress bar the second time
-// TODO: fix the iOS CBCenteralManager not initializing properly the first time scanning is requested
-
 /// This provider provides the Bluetooth scanner.
 ///
 /// This provider is not an `autoDispose` provider,

--- a/lib/riverpod/bluetooth_provider.dart
+++ b/lib/riverpod/bluetooth_provider.dart
@@ -1,6 +1,9 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/bluetooth/bluetooth_device_scanner.dart';
 
+// TODO: regression test for scanning twice in a row not showing the scanning progress bar the second time
+// TODO: fix the iOS CBCenteralManager not initializing properly the first time scanning is requested
+
 /// This provider provides the Bluetooth scanner.
 ///
 /// This provider is not an `autoDispose` provider,

--- a/lib/riverpod/bluetooth_provider.dart
+++ b/lib/riverpod/bluetooth_provider.dart
@@ -1,8 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/bluetooth/bluetooth_device_scanner.dart';
 
-/// This provider provides the bluetooth scanner.
-final bluetoothProvider = Provider.autoDispose<BluetoothDeviceScanner>((ref) {
+/// This provider provides the Bluetooth scanner.
+///
+/// This provider is not an `autoDispose` provider,
+/// as the Bluetooth scanner can be reused multiple times.
+/// It is disposed using [ProviderRef.onDispose] when the [ProviderContainer] is disposed.
+final bluetoothProvider = Provider<BluetoothDeviceScanner>((ref) {
   final scanner = BluetoothDeviceScannerImpl();
 
   ref.onDispose(scanner.dispose);

--- a/lib/widgets/pages/home_page.dart
+++ b/lib/widgets/pages/home_page.dart
@@ -71,6 +71,7 @@ class _HomePageState extends State<HomePage> {
 
   Widget _buildAndroidWidget(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       body: _buildPageView(context),
       bottomNavigationBar: Theme(
         data: ThemeData(

--- a/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
@@ -39,8 +39,16 @@ class AddExcludedTermInputField extends StatelessWidget {
     }
 
     delegate.addTerm(formState.value!);
+
+    // After the new excluded term is added,
+    // clear the text so a new term can be entered,
+    // reset the form state so that the validation error for an empty field is removed
+    // (which is caused by clearing the text field).
+    // Finally unfocus the text field, as keeping it focused
+    // makes it less obvious that a new term can be added.
     controller.clear();
     formState.reset();
+    focusNode.unfocus();
   }
 
   @override

--- a/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/model/settings/excluded_terms_delegate.dart';
 import 'package:weforza/widgets/pages/settings/excluded_terms/excluded_term_input_field.dart';
@@ -44,11 +45,15 @@ class AddExcludedTermInputField extends StatelessWidget {
     // clear the text so a new term can be entered,
     // reset the form state so that the validation error for an empty field is removed
     // (which is caused by clearing the text field).
-    // Finally unfocus the text field, as keeping it focused
-    // makes it less obvious that a new term can be added.
     controller.clear();
     formState.reset();
-    focusNode.unfocus();
+
+    // Finally unfocus the text field, as keeping it focused
+    // makes it less obvious that a new term can be added.
+    // However, do this in the next frame, otherwise the text in the text field is not cleared.
+    SchedulerBinding.instance.addPostFrameCallback((timeStamp) {
+      focusNode.unfocus();
+    });
   }
 
   @override

--- a/lib/widgets/pages/settings/settings_page.dart
+++ b/lib/widgets/pages/settings/settings_page.dart
@@ -46,9 +46,7 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
 
     excludedTermsDelegate = ExcludedTermsDelegate(
       settingsDelegate: settingsDelegate,
-      initialValue: currentSettings.excludedTermsFilter
-          .map((t) => ExcludedTerm(term: t))
-          .toList(),
+      initialValue: currentSettings.excludedTermsFilter.map((t) => ExcludedTerm(term: t)).toList(),
     );
     riderFilterDelegate = RiderFilterDelegate(
       settingsDelegate: settingsDelegate,
@@ -86,6 +84,7 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
     final textTheme = theme.textTheme;
 
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       appBar: AppBar(title: Text(translator.settings)),
       body: SettingsPageScrollView(
         excludedTermsListHeader: const Padding(
@@ -183,6 +182,7 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
     );
 
     return CupertinoPageScaffold(
+      resizeToAvoidBottomInset: false,
       backgroundColor: CupertinoColors.systemGroupedBackground,
       child: SettingsPageScrollView(
         excludedTermsList: SliverPadding(


### PR DESCRIPTION
This PR adds the following fixes:

- unfocus the add excluded term input field after an item is added
- revert using an autodispose provider for the Bluetooth scanner
- fix a typo `fale` -> `fake`
- add a missing `resizeToAvoidBottomInset: false` to the Android home page
- use an `unawaited` in one place
- fix additional keyboard padding on the settings page using `resizeToAvoidBottomInset: false`