### PR TITLE
Restore package attribute in manifest

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="be.weforza.app">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
+    package="be.weforza.app">
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
     <!-- flutter_blue_plus 1.3.0 does not opt out of never for location, which breaks compatibility with BLE beacons -->
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" tools:node="replace"/>

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="be.weforza.app">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->


### PR DESCRIPTION
This PR temporarily restores the `package` attribute in the `Manifest.xml` to unblock Android builds.

Once the tooling is updated to handle `namespace` as well, this can be reverted.

The revert is tracked by #313 