### PR TITLE
M3 migration - navigation bar

### DIFF
--- a/lib/widgets/pages/home_page/home_page.dart
+++ b/lib/widgets/pages/home_page/home_page.dart
@@ -67,7 +67,6 @@ class _HomePageState extends State<HomePage> {
         child: NavigationBar(
           selectedIndex: _selectedTab.tabIndex,
           onDestinationSelected: (index) => _onNavigationDestinationSelected(context, index),
-          labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
           destinations: <NavigationDestination>[
             NavigationDestination(
               icon: const Icon(Icons.directions_bike),

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -16,7 +16,8 @@ abstract class AppTheme {
     navigationBarTheme: NavigationBarThemeData(
       backgroundColor: colorScheme.surface,
       surfaceTintColor: colorScheme.surfaceTint,
-      indicatorColor: colorScheme.primaryContainer,
+      indicatorColor: const Color(0xffc2e7ff),
+      labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
     ),
     segmentedButtonTheme: SegmentedButtonThemeData(
       style: ButtonStyle(

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -14,8 +14,8 @@ abstract class AppTheme {
       DestructiveButtons(errorColor: colorScheme.error),
     ],
     navigationBarTheme: NavigationBarThemeData(
-      // The default is secondaryContainer,
-      // which is a little harder to see.
+      backgroundColor: colorScheme.surface,
+      surfaceTintColor: colorScheme.surfaceTint,
       indicatorColor: colorScheme.primaryContainer,
     ),
     segmentedButtonTheme: SegmentedButtonThemeData(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,7 +59,7 @@ dependencies:
   jiffy: ^5.0.0
 
   # package_info_plus provides access to app specific information such as build number & version.
-  package_info_plus: ^3.0.2
+  package_info_plus: ^3.0.3
 
   # Path utilities for URI's and the like.
   path: ^1.8.1


### PR DESCRIPTION
This PR updates the bottom navigation bar to Material 3 color schemes.
I took the selected color for the M3 website, since it is not included in the generated color scheme.

Part of #170  