### PR TITLE
M3 migration - scan result background color + overscroll indicator fix

### DIFF
--- a/lib/widgets/custom/scroll_behavior.dart
+++ b/lib/widgets/custom/scroll_behavior.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/cupertino.dart';
+
+/// This class represents a [ScrollBehavior] that does not apply an overscroll indicator to its child.
+class NoOverscrollIndicatorScrollBehavior extends ScrollBehavior {
+  const NoOverscrollIndicatorScrollBehavior();
+
+  @override
+  Widget buildOverscrollIndicator(BuildContext context, Widget child, ScrollableDetails details) {
+    return child;
+  }
+}

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list.dart
@@ -6,6 +6,7 @@ import 'package:weforza/model/ride_attendee_scanning/ride_attendee_scanning_dele
 import 'package:weforza/model/rider/rider.dart';
 import 'package:weforza/widgets/common/focus_absorber.dart';
 import 'package:weforza/widgets/common/rider_search_filter_empty.dart';
+import 'package:weforza/widgets/custom/scroll_behavior.dart';
 import 'package:weforza/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart';
 import 'package:weforza/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_bottom_bar.dart';
 import 'package:weforza/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_filter_delegate.dart';
@@ -146,12 +147,17 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
                   return const RiderSearchFilterEmpty();
                 }
 
-                return ListView.builder(
-                  itemBuilder: (context, index) => ManualSelectionListItem(
-                    delegate: widget.delegate,
-                    item: results[index],
+                return ScrollConfiguration(
+                  // Use a custom scroll behavior that does not build a stretching overscroll indicator.
+                  // Otherwise there are issues with gaps in the selected color of adjacent selected scan results.
+                  behavior: const NoOverscrollIndicatorScrollBehavior(),
+                  child: ListView.builder(
+                    itemBuilder: (context, index) => ManualSelectionListItem(
+                      delegate: widget.delegate,
+                      item: results[index],
+                    ),
+                    itemCount: results.length,
                   ),
-                  itemCount: results.length,
                 );
               },
             ),

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_item.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_item.dart
@@ -34,7 +34,7 @@ class _ManualSelectionListItemState extends ConsumerState<ManualSelectionListIte
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
-          return BoxDecoration(color: Theme.of(context).primaryColorDark);
+          return BoxDecoration(color: Theme.of(context).primaryColor.withOpacity(0.6));
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
           return BoxDecoration(color: CupertinoTheme.of(context).primaryColor);


### PR DESCRIPTION
This PR updates the background color for the scan results on Android. It also disables the overscroll effect for the manual selection list.