### PR TITLE
Fix iOS Bluetooth adapter state

### DIFF
--- a/lib/bluetooth/bluetooth_device_scanner.dart
+++ b/lib/bluetooth/bluetooth_device_scanner.dart
@@ -8,8 +8,11 @@ abstract class BluetoothDeviceScanner {
   /// Check whether bluetooth is enabled.
   Future<bool> isBluetoothEnabled();
 
+  /// Get the current scanning state.
+  bool get isScanning;
+
   /// Get the stream of changes to the scanning state.
-  Stream<bool> get isScanning;
+  Stream<bool> get isScanningStream;
 
   /// Scan for bluetooth devices.
   /// The [scanDurationInSeconds] indicates the length of the scan in seconds.
@@ -31,7 +34,10 @@ class BluetoothDeviceScannerImpl implements BluetoothDeviceScanner {
   Future<bool> isBluetoothEnabled() => _fBlInstance.isOn;
 
   @override
-  Stream<bool> get isScanning => _fBlInstance.isScanning;
+  bool get isScanning => _fBlInstance.isScanning;
+
+  @override
+  Stream<bool> get isScanningStream => _fBlInstance.isScanningStream;
 
   @override
   Stream<BluetoothPeripheral> scanForDevices(int scanDurationInSeconds) {

--- a/lib/bluetooth/bluetooth_device_scanner.dart
+++ b/lib/bluetooth/bluetooth_device_scanner.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:weforza/bluetooth/bluetooth_peripheral.dart';
@@ -31,7 +32,87 @@ class BluetoothDeviceScannerImpl implements BluetoothDeviceScanner {
   final FlutterBluePlus _fBlInstance = FlutterBluePlus.instance;
 
   @override
-  Future<bool> isBluetoothEnabled() => _fBlInstance.isOn;
+  Future<bool> isBluetoothEnabled() async {
+    if (Platform.isAndroid) {
+      return _fBlInstance.isOn;
+    }
+
+    // On iOS, the `CBCentralManager` might still be in the `BluetoothState.unknown` state
+    // at the time of requesting the state of the Bluetooth adapter.
+    // If the adapter indicates that is it on, return early.
+    // If it is not, defer to the actual state of the adapter to find out the real state.
+    if (Platform.isIOS) {
+      final bool isOn = await _fBlInstance.isOn;
+
+      if (isOn) {
+        return true;
+      }
+
+      final Completer<bool> completer = Completer();
+      StreamSubscription<BluetoothState>? subscription;
+
+      subscription = _fBlInstance.state.listen(
+        (state) {
+          switch (state) {
+            case BluetoothState.off:
+            case BluetoothState.turningOff:
+              // Complete with the value and cancel the subscription.
+              if (!completer.isCompleted) {
+                subscription?.cancel();
+                subscription = null;
+                completer.complete(false);
+              }
+              break;
+            case BluetoothState.on:
+              // Complete with the value and cancel the subscription.
+              if (!completer.isCompleted) {
+                subscription?.cancel();
+                subscription = null;
+                completer.complete(true);
+              }
+              break;
+            case BluetoothState.unauthorized:
+              // Complete with the error and cancel the subscription.
+              if (!completer.isCompleted) {
+                subscription?.cancel();
+                subscription = null;
+                completer.completeError(StateError('Access to Bluetooth was not authorized.'), StackTrace.current);
+              }
+              break;
+            case BluetoothState.unavailable:
+              // Complete with the error and cancel the subscription.
+              if (!completer.isCompleted) {
+                subscription?.cancel();
+                subscription = null;
+                completer.completeError(
+                  UnsupportedError('Bluetooth is not supported on this device.'),
+                  StackTrace.current,
+                );
+              }
+              break;
+            case BluetoothState.unknown:
+            case BluetoothState.turningOn:
+              // If the state is unknown, wait for it to resolve.
+              // If the state is turning on, wait for it to switch to `BluetoothState.on`.
+              break;
+          }
+        },
+        cancelOnError: true,
+        onError: (error, stackTrace) {
+          // Complete with the error and cancel the subscription.
+          if (!completer.isCompleted) {
+            subscription?.cancel();
+            subscription = null;
+            completer.completeError(error, stackTrace);
+          }
+        },
+      );
+
+      return completer.future;
+    }
+
+    throw UnsupportedError('Only Android and iOS are supported.');
+  }
 
   @override
   bool get isScanning => _fBlInstance.isScanning;

--- a/lib/bluetooth/mock_bluetooth_scanner.dart
+++ b/lib/bluetooth/mock_bluetooth_scanner.dart
@@ -54,7 +54,10 @@ class MockBluetoothScanner implements BluetoothDeviceScanner {
   Future<bool> isBluetoothEnabled() async => true;
 
   @override
-  Stream<bool> get isScanning => _scanningController;
+  bool get isScanning => _scanningController.value;
+
+  @override
+  Stream<bool> get isScanningStream => _scanningController;
 
   @override
   Stream<BluetoothPeripheral> scanForDevices(int scanDurationInSeconds) {
@@ -74,7 +77,7 @@ class MockBluetoothScanner implements BluetoothDeviceScanner {
 
   @override
   Future<void> stopScan() async {
-    if (!_scanningController.isClosed) {
+    if (!_scanningController.isClosed && isScanning) {
       _stopScanPill.add(null);
       _scanningController.add(false);
     }

--- a/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
+++ b/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
@@ -37,7 +37,7 @@ class RideAttendeeScanningDelegate {
           vsync: vsync,
           value: 1.0,
         ) {
-    _startScanningSubscription = scanner.isScanning.listen(_listenToScanStart);
+    _startScanningSubscription = scanner.isScanningStream.listen(_listenToScanStart);
   }
 
   /// The repository that loads all the devices.

--- a/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_page.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/ride_attendee_scanning_page.dart
@@ -95,6 +95,7 @@ class RideAttendeeScanningPageState extends ConsumerState<RideAttendeeScanningPa
               progressBar: ScanProgressIndicator(
                 animationController: delegate.progressBarController,
                 isScanning: delegate.scanner.isScanning,
+                isScanningStream: delegate.scanner.isScanningStream,
               ),
               scanResultsListKey: _scanResultsKey,
             );

--- a/lib/widgets/pages/ride_attendee_scanning_page/scan_button.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/scan_button.dart
@@ -52,7 +52,8 @@ class StopScanButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<bool>(
-      stream: delegate.scanner.isScanning,
+      initialData: delegate.scanner.isScanning,
+      stream: delegate.scanner.isScanningStream,
       builder: (context, snapshot) {
         final isScanning = snapshot.data;
         final translator = S.of(context);

--- a/lib/widgets/pages/ride_attendee_scanning_page/scan_progress_indicator.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/scan_progress_indicator.dart
@@ -8,14 +8,18 @@ class ScanProgressIndicator extends StatelessWidget {
   const ScanProgressIndicator({
     required this.animationController,
     required this.isScanning,
+    required this.isScanningStream,
     super.key,
   });
 
   /// The controller that drives the progress bar animation.
   final AnimationController animationController;
 
-  /// The stream that indicates if there is a running scan.
-  final Stream<bool> isScanning;
+  /// Whether a device scan is currently in progress.
+  final bool isScanning;
+
+  /// The stream of changes to the scanning state.
+  final Stream<bool> isScanningStream;
 
   Widget _buildProgressIndicator(double progress, Color color) {
     return LinearProgressIndicator(
@@ -28,7 +32,8 @@ class ScanProgressIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<bool>(
-      stream: isScanning,
+      initialData: isScanning,
+      stream: isScanningStream,
       builder: (context, snapshot) {
         final value = snapshot.data;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: d2494157c32b303f47dedee955b1479f2979c4ff66934eb7c0def44fd9e0267a
+      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.1"
+    version: "1.6.3"
   cross_file:
     dependency: transitive
     description:
@@ -193,11 +193,12 @@ packages:
   flutter_blue_plus:
     dependency: "direct main"
     description:
-      name: flutter_blue_plus
-      sha256: "60d1ac25b680cf9e031ebabad000dc61bfdffbfad51ce3d96bce0ce4834109cf"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.1"
+      path: "."
+      ref: patch_ios_bluetooth_state
+      resolved-ref: "7d40c2671c7911ef1e5709f20135867fa49b871d"
+      url: "git@github.com:navaronbracke/flutter_blue_plus.git"
+    source: git
+    version: "1.5.0"
   flutter_driver:
     dependency: "direct dev"
     description: flutter
@@ -432,10 +433,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: f619162573096d428ccde2e33f92e05b5a179cd6f0e3120c1005f181bee8ed16
+      sha256: "8df5ab0a481d7dc20c0e63809e90a588e496d276ba53358afc4c4443d0a00697"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   package_info_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,6 @@
 name: weforza
 description: The WeForza App
+publish_to: none
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -41,7 +42,11 @@ dependencies:
     sdk: flutter
 
   # This package provides Bluetooth Low Energy functionality.
-  flutter_blue_plus: ^1.3.1
+  # TODO: remove the fork when we self-own the Bluetooth adapter code.
+  flutter_blue_plus:
+    git:
+      url: git@github.com:navaronbracke/flutter_blue_plus.git
+      ref: patch_ios_bluetooth_state
 
   flutter_localizations:
     sdk: flutter


### PR DESCRIPTION
This PR fixes a state bug for the iOS implementation of the Bluetooth device scanner.

It also changes the dependency reference of `flutter_blue_plus` to a local fork.

Fixes #304 