### PR TITLE
Add close button to search field

### DIFF
--- a/lib/widgets/common/search_field_with_clear_button.dart
+++ b/lib/widgets/common/search_field_with_clear_button.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:weforza/widgets/platform/platform_aware_widget.dart';
+
+/// This widget represents a search field that has a clear button at the end if there is text in the search field.
+class SearchFieldWithClearButton extends StatelessWidget {
+  const SearchFieldWithClearButton({
+    required this.controller,
+    required this.focusNode,
+    required this.onChanged,
+    required this.placeholder,
+    super.key,
+  });
+
+  /// The controller for the text field.
+  final TextEditingController controller;
+
+  /// The focus node for the text field.
+  final FocusNode focusNode;
+
+  /// The function that is called when the text field value changes.
+  final void Function(String value) onChanged;
+
+  /// The placeholder label for the text field.
+  final String placeholder;
+
+  @override
+  Widget build(BuildContext context) {
+    return PlatformAwareWidget(
+      android: (context) => TextField(
+        focusNode: focusNode,
+        controller: controller,
+        onChanged: onChanged,
+        textInputAction: TextInputAction.search,
+        keyboardType: TextInputType.text,
+        autocorrect: false,
+        decoration: InputDecoration(
+          floatingLabelBehavior: FloatingLabelBehavior.never,
+          border: InputBorder.none,
+          contentPadding: const EdgeInsets.symmetric(horizontal: 4),
+          labelText: placeholder,
+          suffixIcon: ValueListenableBuilder<TextEditingValue>(
+            valueListenable: controller,
+            builder: (_, value, child) {
+              return value.text.isEmpty
+                  ? const Icon(Icons.search)
+                  : IconButton(onPressed: controller.clear, icon: const Icon(Icons.clear));
+            },
+          ),
+        ),
+      ),
+      ios: (context) => Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: CupertinoSearchTextField(
+          focusNode: focusNode,
+          controller: controller,
+          onChanged: onChanged,
+          autocorrect: false,
+          placeholder: placeholder,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list.dart
@@ -6,6 +6,7 @@ import 'package:weforza/model/ride_attendee_scanning/ride_attendee_scanning_dele
 import 'package:weforza/model/rider/rider.dart';
 import 'package:weforza/widgets/common/focus_absorber.dart';
 import 'package:weforza/widgets/common/rider_search_filter_empty.dart';
+import 'package:weforza/widgets/common/search_field_with_clear_button.dart';
 import 'package:weforza/widgets/custom/scroll_behavior.dart';
 import 'package:weforza/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart';
 import 'package:weforza/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_bottom_bar.dart';
@@ -15,7 +16,6 @@ import 'package:weforza/widgets/pages/ride_attendee_scanning_page/manual_selecti
 import 'package:weforza/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_save_button.dart';
 import 'package:weforza/widgets/pages/ride_attendee_scanning_page/manual_selection_list/show_scanned_results_toggle.dart';
 import 'package:weforza/widgets/platform/platform_aware_loading_indicator.dart';
-import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 
 /// This widget represents the list of active riders that is shown
 /// after the device scan has ended,
@@ -37,6 +37,8 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
   Future<List<Rider>>? _activeRidersFuture;
 
   final _filtersController = ManualSelectionFilterDelegate();
+  final _searchFieldFocusNode = FocusNode();
+  final _searchFieldController = TextEditingController();
 
   Future<void>? _saveFuture;
 
@@ -107,34 +109,14 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
   }
 
   Widget _buildActiveRidersList(BuildContext context, List<Rider> items) {
-    final translator = S.of(context);
-
     return FocusAbsorber(
       child: Column(
         children: <Widget>[
-          PlatformAwareWidget(
-            android: (_) => TextFormField(
-              textInputAction: TextInputAction.search,
-              keyboardType: TextInputType.text,
-              autocorrect: false,
-              autovalidateMode: AutovalidateMode.disabled,
-              onChanged: _filtersController.onSearchQueryChanged,
-              decoration: InputDecoration(
-                suffixIcon: const Icon(Icons.search),
-                labelText: translator.searchRiders,
-                border: InputBorder.none,
-                contentPadding: const EdgeInsets.symmetric(horizontal: 4),
-                floatingLabelBehavior: FloatingLabelBehavior.never,
-              ),
-            ),
-            ios: (_) => Padding(
-              padding: const EdgeInsets.all(8),
-              child: CupertinoSearchTextField(
-                suffixIcon: const Icon(CupertinoIcons.search),
-                onChanged: _filtersController.onSearchQueryChanged,
-                placeholder: translator.searchRiders,
-              ),
-            ),
+          SearchFieldWithClearButton(
+            controller: _searchFieldController,
+            focusNode: _searchFieldFocusNode,
+            onChanged: _filtersController.onSearchQueryChanged,
+            placeholder: S.of(context).searchRiders,
           ),
           Expanded(
             child: StreamBuilder<ManualSelectionFilterOptions>(
@@ -203,6 +185,8 @@ class _ManualSelectionListState extends State<ManualSelectionList> {
 
   @override
   void dispose() {
+    _searchFieldController.dispose();
+    _searchFieldFocusNode.dispose();
     _filtersController.dispose();
     super.dispose();
   }

--- a/lib/widgets/pages/rider_list/rider_list.dart
+++ b/lib/widgets/pages/rider_list/rider_list.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/generated/l10n.dart';
@@ -8,11 +7,11 @@ import 'package:weforza/riverpod/rider/rider_list_provider.dart';
 import 'package:weforza/widgets/common/focus_absorber.dart';
 import 'package:weforza/widgets/common/generic_error.dart';
 import 'package:weforza/widgets/common/rider_search_filter_empty.dart';
+import 'package:weforza/widgets/common/search_field_with_clear_button.dart';
 import 'package:weforza/widgets/pages/rider_details/rider_details_page.dart';
 import 'package:weforza/widgets/pages/rider_list/rider_list_empty.dart';
 import 'package:weforza/widgets/pages/rider_list/rider_list_item.dart';
 import 'package:weforza/widgets/platform/platform_aware_loading_indicator.dart';
-import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 
 /// This widget represents the list of riders.
 class RiderList extends StatefulWidget {
@@ -26,6 +25,7 @@ class _RiderListState extends State<RiderList> {
   final _searchController = DebounceSearchDelegate();
 
   final _searchFieldController = TextEditingController();
+  final _searchFieldFocusNode = FocusNode();
 
   void _onRiderSelected(BuildContext context) {
     // Clear the search query.
@@ -67,30 +67,11 @@ class _RiderListState extends State<RiderList> {
   Widget _buildRiderList(BuildContext context) {
     final String placeholder = S.of(context).searchRiders;
 
-    final Widget searchField = PlatformAwareWidget(
-      android: (context) => TextField(
-        controller: _searchFieldController,
-        textInputAction: TextInputAction.search,
-        keyboardType: TextInputType.text,
-        autocorrect: false,
-        onChanged: _searchController.onQueryChanged,
-        decoration: InputDecoration(
-          suffixIcon: const Icon(Icons.search),
-          labelText: placeholder,
-          border: InputBorder.none,
-          contentPadding: const EdgeInsets.symmetric(horizontal: 4),
-          floatingLabelBehavior: FloatingLabelBehavior.never,
-        ),
-      ),
-      ios: (context) => Padding(
-        padding: const EdgeInsets.all(8),
-        child: CupertinoSearchTextField(
-          controller: _searchFieldController,
-          suffixIcon: const Icon(CupertinoIcons.search),
-          onChanged: _searchController.onQueryChanged,
-          placeholder: placeholder,
-        ),
-      ),
+    final Widget searchField = SearchFieldWithClearButton(
+      controller: _searchFieldController,
+      focusNode: _searchFieldFocusNode,
+      onChanged: _searchController.onQueryChanged,
+      placeholder: placeholder,
     );
 
     return Consumer(
@@ -150,6 +131,7 @@ class _RiderListState extends State<RiderList> {
   @override
   void dispose() {
     _searchController.dispose();
+    _searchFieldFocusNode.dispose();
     _searchFieldController.dispose();
     super.dispose();
   }


### PR DESCRIPTION
This PR adds the following changes:
- merge the two search fields into one widget
- fix TextFormField usage that should have been a TextField
- leverage the functionality in `CupertinoSearchField` to handle the clear
- add a clear button to the Material search field

Fixes #324 