### PR TITLE
Excluded term input field cleanup

### DIFF
--- a/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
@@ -17,13 +17,9 @@ class AddExcludedTermInputField extends StatelessWidget {
     required this.delegate,
     required this.focusNode,
     required this.formKey,
-    this.bottom,
     this.decoration,
     super.key,
   });
-
-  /// The widget below this text field.
-  final Widget? bottom;
 
   /// The controller for the text field.
   final TextEditingController controller;
@@ -68,7 +64,7 @@ class AddExcludedTermInputField extends StatelessWidget {
   Widget build(BuildContext context) {
     final translator = S.of(context);
 
-    final Widget child = ExcludedTermInputField(
+    return ExcludedTermInputField(
       controller: controller,
       decoration: decoration,
       focusNode: focusNode,
@@ -85,15 +81,6 @@ class AddExcludedTermInputField extends StatelessWidget {
       textFieldKey: formKey,
       validator: (value) => delegate.validateTerm(value, translator),
       placeholder: translator.addDisallowedWord,
-    );
-
-    if (bottom == null) {
-      return child;
-    }
-
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: <Widget>[child, bottom!],
     );
   }
 }

--- a/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
@@ -17,9 +17,13 @@ class AddExcludedTermInputField extends StatelessWidget {
     required this.delegate,
     required this.focusNode,
     required this.formKey,
+    this.bottom,
     this.decoration,
     super.key,
   });
+
+  /// The widget below this text field.
+  final Widget? bottom;
 
   /// The controller for the text field.
   final TextEditingController controller;
@@ -64,7 +68,7 @@ class AddExcludedTermInputField extends StatelessWidget {
   Widget build(BuildContext context) {
     final translator = S.of(context);
 
-    return ExcludedTermInputField(
+    final Widget child = ExcludedTermInputField(
       controller: controller,
       decoration: decoration,
       focusNode: focusNode,
@@ -81,6 +85,15 @@ class AddExcludedTermInputField extends StatelessWidget {
       textFieldKey: formKey,
       validator: (value) => delegate.validateTerm(value, translator),
       placeholder: translator.addDisallowedWord,
+    );
+
+    if (bottom == null) {
+      return child;
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[child, bottom!],
     );
   }
 }

--- a/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
@@ -17,11 +17,15 @@ class AddExcludedTermInputField extends StatelessWidget {
     required this.delegate,
     required this.focusNode,
     required this.formKey,
+    this.decoration,
     super.key,
   });
 
   /// The controller for the text field.
   final TextEditingController controller;
+
+  /// The decoration for the text field.
+  final BoxDecoration? decoration;
 
   /// The delegate that manages the list of terms.
   final ExcludedTermsDelegate delegate;
@@ -62,6 +66,7 @@ class AddExcludedTermInputField extends StatelessWidget {
 
     return ExcludedTermInputField(
       controller: controller,
+      decoration: decoration,
       focusNode: focusNode,
       maxLength: delegate.maxLength,
       onEditingComplete: _onEditingComplete,

--- a/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field.dart
@@ -196,7 +196,20 @@ class _EditExcludedTermInputFieldState extends State<EditExcludedTermInputField>
 
   @override
   Widget build(BuildContext context) {
-    final textFieldWidget = ExcludedTermInputField(
+    final Widget contextMenuButtonBar = EditExcludedTermInputFieldButtonBar(
+      controller: widget.excludedTerm.controller,
+      onCommitValidTerm: (value) => _onCommitValidTerm(value, context),
+      onDeletePressed: _onDeletePressed,
+      onUndoPressed: _onUndoPressed,
+      term: widget.excludedTerm.term,
+      validator: _validateTerm,
+    );
+
+    return ExcludedTermInputField(
+      // The context menu is shown when the text field has focus,
+      // or if the delete dialog is visible after pressing the delete button.
+      // When pressing the delete button focus moves to the delete dialog.
+      contextMenuButtonBar: deleteDialogVisible || focusNode.hasFocus ? contextMenuButtonBar : null,
       controller: widget.excludedTerm.controller,
       focusNode: focusNode,
       maxLength: widget.delegate.maxLength,
@@ -204,33 +217,6 @@ class _EditExcludedTermInputFieldState extends State<EditExcludedTermInputField>
       textFieldKey: textFieldKey,
       validator: (value) => _validateTerm(context, value),
     );
-
-    // If the delete dialog is visible, the edit menu should not be closed.
-    if (deleteDialogVisible || focusNode.hasFocus) {
-      return GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: () {
-          // Consume gestures so that they are not handled by the focus absorber.
-        },
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            textFieldWidget,
-            EditExcludedTermInputFieldButtonBar(
-              controller: widget.excludedTerm.controller,
-              onCommitValidTerm: (value) => _onCommitValidTerm(value, context),
-              onDeletePressed: _onDeletePressed,
-              onUndoPressed: _onUndoPressed,
-              term: widget.excludedTerm.term,
-              validator: _validateTerm,
-            ),
-          ],
-        ),
-      );
-    }
-
-    return textFieldWidget;
   }
 
   @override

--- a/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field.dart
@@ -17,6 +17,7 @@ class EditExcludedTermInputField extends StatefulWidget {
     required this.excludedTerm,
     required this.scrollController,
     this.decoration,
+    this.divider,
   }) : super(key: ValueKey(excludedTerm.term));
 
   /// The decoration for the text field and the context menu.
@@ -24,6 +25,12 @@ class EditExcludedTermInputField extends StatefulWidget {
 
   /// The delegate that manages the excluded terms.
   final ExcludedTermsDelegate delegate;
+
+  /// The divider that is placed above the text field.
+  ///
+  /// This widget is typically used to add separators
+  /// between this widget and the previous one in a list of [ExcludedTermInputField]s.
+  final Widget? divider;
 
   /// The index of [excludedTerm] in the list of terms.
   final int index;
@@ -216,6 +223,7 @@ class _EditExcludedTermInputFieldState extends State<EditExcludedTermInputField>
       contextMenuButtonBar: deleteDialogVisible || focusNode.hasFocus ? contextMenuButtonBar : null,
       controller: widget.excludedTerm.controller,
       decoration: widget.decoration,
+      divider: widget.divider,
       focusNode: focusNode,
       maxLength: widget.delegate.maxLength,
       onEditingComplete: () => _onEditingComplete(context),

--- a/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field.dart
@@ -16,7 +16,11 @@ class EditExcludedTermInputField extends StatefulWidget {
     required this.index,
     required this.excludedTerm,
     required this.scrollController,
+    this.decoration,
   }) : super(key: ValueKey(excludedTerm.term));
+
+  /// The decoration for the text field and the context menu.
+  final BoxDecoration? decoration;
 
   /// The delegate that manages the excluded terms.
   final ExcludedTermsDelegate delegate;
@@ -211,6 +215,7 @@ class _EditExcludedTermInputFieldState extends State<EditExcludedTermInputField>
       // When pressing the delete button focus moves to the delete dialog.
       contextMenuButtonBar: deleteDialogVisible || focusNode.hasFocus ? contextMenuButtonBar : null,
       controller: widget.excludedTerm.controller,
+      decoration: widget.decoration,
       focusNode: focusNode,
       maxLength: widget.delegate.maxLength,
       onEditingComplete: () => _onEditingComplete(context),

--- a/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field_button_bar.dart
+++ b/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field_button_bar.dart
@@ -89,7 +89,6 @@ class EditExcludedTermInputFieldButtonBar extends StatelessWidget {
         );
 
         return Row(
-          mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             undoButton,

--- a/lib/widgets/pages/settings/excluded_terms/excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/excluded_term_input_field.dart
@@ -14,6 +14,7 @@ class ExcludedTermInputField extends StatelessWidget {
     required this.validator,
     this.contextMenuButtonBar,
     this.decoration,
+    this.divider,
     this.placeholder,
     this.suffix,
     this.textFieldKey,
@@ -28,6 +29,9 @@ class ExcludedTermInputField extends StatelessWidget {
 
   /// The decoration to apply to the text field and the context menu.
   final BoxDecoration? decoration;
+
+  /// The divider that is placed above the text field.
+  final Widget? divider;
 
   /// The focus node for the text field.
   final FocusNode focusNode;
@@ -108,12 +112,29 @@ class ExcludedTermInputField extends StatelessWidget {
     );
   }
 
-  Widget _wrapWithDecoration(Widget child, {BoxDecoration? decoration}) {
-    if (decoration == null) {
-      return child;
+  Widget _wrapWithDecoration(
+    Widget child, {
+    Widget? contextMenu,
+    BoxDecoration? decoration,
+    Widget? divider,
+  }) {
+    if (contextMenu != null || divider != null) {
+      child = Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          if (divider != null) divider,
+          child,
+          if (contextMenu != null) contextMenu,
+        ],
+      );
     }
 
-    return DecoratedBox(decoration: decoration, child: child);
+    if (decoration != null) {
+      child = DecoratedBox(decoration: decoration, child: child);
+    }
+
+    return child;
   }
 
   @override
@@ -122,7 +143,7 @@ class ExcludedTermInputField extends StatelessWidget {
     final Widget? contextMenu = contextMenuButtonBar;
 
     if (contextMenu == null) {
-      return _wrapWithDecoration(textField, decoration: decoration);
+      return _wrapWithDecoration(textField, decoration: decoration, divider: divider);
     }
 
     return GestureDetector(
@@ -132,12 +153,10 @@ class ExcludedTermInputField extends StatelessWidget {
         // Otherwise the context menu would be closed when tapping on its blank areas.
       },
       child: _wrapWithDecoration(
-        Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[textField, contextMenu],
-        ),
+        textField,
+        contextMenu: contextMenu,
         decoration: decoration,
+        divider: divider,
       ),
     );
   }

--- a/lib/widgets/pages/settings/excluded_terms/excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/excluded_term_input_field.dart
@@ -12,11 +12,15 @@ class ExcludedTermInputField extends StatelessWidget {
     required this.maxLength,
     required this.onEditingComplete,
     required this.validator,
+    this.contextMenuButtonBar,
     this.placeholder,
     this.suffix,
     this.textFieldKey,
     super.key,
   });
+
+  /// The widget that acts as the context menu button bar below the text field.
+  final Widget? contextMenuButtonBar;
 
   /// The controller for the text field.
   final TextEditingController controller;
@@ -43,7 +47,7 @@ class ExcludedTermInputField extends StatelessWidget {
   final String? Function(String? value) validator;
 
   /// Build the invisible counter. The max length is enforced by the text field.
-  Widget? _buildCounter(
+  Widget? _buildAndroidCounter(
     BuildContext context, {
     required int currentLength,
     required bool isFocused,
@@ -52,13 +56,12 @@ class ExcludedTermInputField extends StatelessWidget {
     return null;
   }
 
-  @override
-  Widget build(BuildContext context) {
+  Widget _buildTextField() {
     return PlatformAwareWidget(
       android: (_) => TextFormField(
         key: textFieldKey,
         autovalidateMode: AutovalidateMode.onUserInteraction,
-        buildCounter: _buildCounter,
+        buildCounter: _buildAndroidCounter,
         controller: controller,
         decoration: InputDecoration(
           border: const UnderlineInputBorder(),
@@ -98,6 +101,29 @@ class ExcludedTermInputField extends StatelessWidget {
 
         return Row(children: [Expanded(child: child), suffix!]);
       },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget textField = _buildTextField();
+    final Widget? contextMenu = contextMenuButtonBar;
+
+    if (contextMenu == null) {
+      return textField;
+    }
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () {
+        // Consume gestures so that they are not handled by the focus absorber.
+        // Otherwise the context menu would be closed when tapping on its blank areas.
+      },
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[textField, contextMenu],
+      ),
     );
   }
 }

--- a/lib/widgets/pages/settings/excluded_terms/excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/excluded_term_input_field.dart
@@ -31,6 +31,9 @@ class ExcludedTermInputField extends StatelessWidget {
   final BoxDecoration? decoration;
 
   /// The divider that is placed above the text field.
+  ///
+  /// This widget is typically used to add separators
+  /// between this widget and the previous one in a list of [ExcludedTermInputField]s.
   final Widget? divider;
 
   /// The focus node for the text field.

--- a/lib/widgets/pages/settings/excluded_terms/excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/excluded_term_input_field.dart
@@ -13,6 +13,7 @@ class ExcludedTermInputField extends StatelessWidget {
     required this.onEditingComplete,
     required this.validator,
     this.contextMenuButtonBar,
+    this.decoration,
     this.placeholder,
     this.suffix,
     this.textFieldKey,
@@ -24,6 +25,9 @@ class ExcludedTermInputField extends StatelessWidget {
 
   /// The controller for the text field.
   final TextEditingController controller;
+
+  /// The decoration to apply to the text field and the context menu.
+  final BoxDecoration? decoration;
 
   /// The focus node for the text field.
   final FocusNode focusNode;
@@ -104,13 +108,21 @@ class ExcludedTermInputField extends StatelessWidget {
     );
   }
 
+  Widget _wrapWithDecoration(Widget child, {BoxDecoration? decoration}) {
+    if (decoration == null) {
+      return child;
+    }
+
+    return DecoratedBox(decoration: decoration, child: child);
+  }
+
   @override
   Widget build(BuildContext context) {
     final Widget textField = _buildTextField();
     final Widget? contextMenu = contextMenuButtonBar;
 
     if (contextMenu == null) {
-      return textField;
+      return _wrapWithDecoration(textField, decoration: decoration);
     }
 
     return GestureDetector(
@@ -119,10 +131,13 @@ class ExcludedTermInputField extends StatelessWidget {
         // Consume gestures so that they are not handled by the focus absorber.
         // Otherwise the context menu would be closed when tapping on its blank areas.
       },
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: <Widget>[textField, contextMenu],
+      child: _wrapWithDecoration(
+        Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[textField, contextMenu],
+        ),
+        decoration: decoration,
       ),
     );
   }

--- a/lib/widgets/pages/settings/excluded_terms/excluded_terms_list.dart
+++ b/lib/widgets/pages/settings/excluded_terms/excluded_terms_list.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/widgets.dart';
 import 'package:weforza/model/settings/excluded_terms_delegate.dart';
 import 'package:weforza/widgets/pages/settings/excluded_terms/excluded_terms_list_empty.dart';
@@ -11,6 +13,7 @@ class ExcludedTermsList extends StatelessWidget {
     required this.builder,
     required this.initialData,
     required this.stream,
+    this.separatorBuilder,
     super.key,
   });
 
@@ -23,8 +26,25 @@ class ExcludedTermsList extends StatelessWidget {
   /// The initial list of terms.
   final List<ExcludedTerm> initialData;
 
+  /// The builder for the item separators.
+  final IndexedWidgetBuilder? separatorBuilder;
+
   /// The stream that provides updates to the list of terms.
   final Stream<List<ExcludedTerm>> stream;
+
+  int? _computeActualChildCount(int itemCount) {
+    int result = itemCount;
+
+    // If the separator builder is specified, the amount of children is doubled,
+    // except for the last child, which is not followed by a separator.
+    if (separatorBuilder != null) {
+      result = max(0, itemCount * 2 - 1);
+    }
+
+    // The add term input is the first item,
+    // so add one to the result.
+    return result + 1;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -50,14 +70,29 @@ class ExcludedTermsList extends StatelessWidget {
         return SliverList(
           delegate: SliverChildBuilderDelegate(
             (context, index) {
+              // The add term input field is always first.
               if (index == 0) {
                 return addTermInputField;
               }
 
-              return builder(terms, index - 1);
+              // Remove the initial offset from the add term input field.
+              index--;
+
+              if (separatorBuilder == null) {
+                return builder(terms, index);
+              }
+
+              // If there is a separator builder,
+              // the real item index is only half of the reported index.
+              final int itemIndex = index ~/ 2;
+
+              if (index.isEven) {
+                return builder(terms, itemIndex);
+              }
+
+              return separatorBuilder!(context, itemIndex);
             },
-            // The add term input is the first item.
-            childCount: terms.length + 1,
+            childCount: _computeActualChildCount(terms.length),
           ),
         );
       },

--- a/lib/widgets/pages/settings/excluded_terms/excluded_terms_list.dart
+++ b/lib/widgets/pages/settings/excluded_terms/excluded_terms_list.dart
@@ -46,6 +46,23 @@ class ExcludedTermsList extends StatelessWidget {
     return result + 1;
   }
 
+  int? _computeSemanticIndex(Widget widget, int index) {
+    // The add term input field does not need a semantic index.
+    if (index == 0) {
+      return null;
+    }
+
+    // Remove the initial offset from the add term input field.
+    index--;
+
+    if (separatorBuilder == null) {
+      return index;
+    }
+
+    // Separators do not get semantic indexes.
+    return index.isEven ? index ~/ 2 : null;
+  }
+
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<List<ExcludedTerm>>(
@@ -93,6 +110,7 @@ class ExcludedTermsList extends StatelessWidget {
               return separatorBuilder!(context, itemIndex);
             },
             childCount: _computeActualChildCount(terms.length),
+            semanticIndexCallback: _computeSemanticIndex,
           ),
         );
       },

--- a/lib/widgets/pages/settings/excluded_terms/excluded_terms_list.dart
+++ b/lib/widgets/pages/settings/excluded_terms/excluded_terms_list.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter/widgets.dart';
 import 'package:weforza/model/settings/excluded_terms_delegate.dart';
 import 'package:weforza/widgets/pages/settings/excluded_terms/excluded_terms_list_empty.dart';
@@ -13,7 +11,6 @@ class ExcludedTermsList extends StatelessWidget {
     required this.builder,
     required this.initialData,
     required this.stream,
-    this.separatorBuilder,
     super.key,
   });
 
@@ -26,25 +23,8 @@ class ExcludedTermsList extends StatelessWidget {
   /// The initial list of terms.
   final List<ExcludedTerm> initialData;
 
-  /// The builder for the item separators.
-  final IndexedWidgetBuilder? separatorBuilder;
-
   /// The stream that provides updates to the list of terms.
   final Stream<List<ExcludedTerm>> stream;
-
-  int? _computeActualChildCount(int itemCount) {
-    int result = itemCount;
-
-    // If the separator builder is specified, the amount of children is doubled,
-    // except for the last child, which is not followed by a separator.
-    if (separatorBuilder != null) {
-      result = max(0, itemCount * 2 - 1);
-    }
-
-    // The add term input is the first item,
-    // so add one to the result.
-    return result + 1;
-  }
 
   int? _computeSemanticIndex(Widget widget, int index) {
     // The add term input field does not need a semantic index.
@@ -53,14 +33,7 @@ class ExcludedTermsList extends StatelessWidget {
     }
 
     // Remove the initial offset from the add term input field.
-    index--;
-
-    if (separatorBuilder == null) {
-      return index;
-    }
-
-    // Separators do not get semantic indexes.
-    return index.isEven ? index ~/ 2 : null;
+    return index - 1;
   }
 
   @override
@@ -93,23 +66,9 @@ class ExcludedTermsList extends StatelessWidget {
               }
 
               // Remove the initial offset from the add term input field.
-              index--;
-
-              if (separatorBuilder == null) {
-                return builder(terms, index);
-              }
-
-              // If there is a separator builder,
-              // the real item index is only half of the reported index.
-              final int itemIndex = index ~/ 2;
-
-              if (index.isEven) {
-                return builder(terms, itemIndex);
-              }
-
-              return separatorBuilder!(context, itemIndex);
+              return builder(terms, index - 1);
             },
-            childCount: _computeActualChildCount(terms.length),
+            childCount: terms.length + 1, // The add term input is the first item.
             semanticIndexCallback: _computeSemanticIndex,
           ),
         );

--- a/lib/widgets/pages/settings/settings_page.dart
+++ b/lib/widgets/pages/settings/settings_page.dart
@@ -157,7 +157,7 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
     );
   }
 
-  Widget _buildExcludedTermItem(List<ExcludedTerm> terms, int index, BoxDecoration? decoration) {
+  Widget _buildExcludedTermItem(List<ExcludedTerm> terms, int index, {BoxDecoration? decoration}) {
     final term = terms[index];
 
     return EditExcludedTermInputField(
@@ -214,7 +214,7 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
             return _buildExcludedTermItem(
               items,
               index,
-              BoxDecoration(
+              decoration: BoxDecoration(
                 borderRadius: borderRadius,
                 color: CupertinoColors.secondarySystemGroupedBackground,
               ),

--- a/lib/widgets/pages/settings/settings_page.dart
+++ b/lib/widgets/pages/settings/settings_page.dart
@@ -180,7 +180,8 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
       excludedTermsList: SliverPadding(
         padding: const EdgeInsets.symmetric(horizontal: 20),
         sliver: ExcludedTermsList(
-          addTermInputField: DecoratedBox(
+          addTermInputField: AddExcludedTermInputField(
+            controller: addTermController,
             decoration: const BoxDecoration(
               borderRadius: BorderRadius.only(
                 topLeft: Radius.circular(10),
@@ -188,12 +189,9 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
               ),
               color: CupertinoColors.secondarySystemGroupedBackground,
             ),
-            child: AddExcludedTermInputField(
-              controller: addTermController,
-              delegate: excludedTermsDelegate,
-              focusNode: addTermFocusNode,
-              formKey: addTermFormKey,
-            ),
+            delegate: excludedTermsDelegate,
+            focusNode: addTermFocusNode,
+            formKey: addTermFormKey,
           ),
           initialData: excludedTermsDelegate.terms,
           stream: excludedTermsDelegate.stream,

--- a/lib/widgets/pages/settings/settings_page.dart
+++ b/lib/widgets/pages/settings/settings_page.dart
@@ -157,12 +157,18 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
     );
   }
 
-  Widget _buildExcludedTermItem(List<ExcludedTerm> terms, int index, {BoxDecoration? decoration}) {
+  Widget _buildExcludedTermItem(
+    List<ExcludedTerm> terms,
+    int index, {
+    BoxDecoration? decoration,
+    Widget? divider,
+  }) {
     final term = terms[index];
 
     return EditExcludedTermInputField(
       decoration: decoration,
       delegate: excludedTermsDelegate,
+      divider: divider,
       index: index,
       excludedTerm: term,
       scrollController: scrollController,
@@ -190,22 +196,12 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
               ),
               color: CupertinoColors.secondarySystemGroupedBackground,
             ),
-            bottom: Container(
-              color: excludedTermDivider.color,
-              height: excludedTermDivider.width,
-              margin: const EdgeInsetsDirectional.only(start: 15.0),
-            ),
             delegate: excludedTermsDelegate,
             focusNode: addTermFocusNode,
             formKey: addTermFormKey,
           ),
           initialData: excludedTermsDelegate.terms,
           stream: excludedTermsDelegate.stream,
-          separatorBuilder: (context, index) => Container(
-            color: excludedTermDivider.color,
-            height: excludedTermDivider.width,
-            margin: const EdgeInsetsDirectional.only(start: 15.0),
-          ),
           builder: (items, index) {
             BorderRadius borderRadius = BorderRadius.zero;
 
@@ -222,6 +218,11 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
               decoration: BoxDecoration(
                 borderRadius: borderRadius,
                 color: CupertinoColors.secondarySystemGroupedBackground,
+              ),
+              divider: Container(
+                color: excludedTermDivider.color,
+                height: excludedTermDivider.width,
+                margin: const EdgeInsetsDirectional.only(start: 15.0),
               ),
             );
           },

--- a/lib/widgets/pages/settings/settings_page.dart
+++ b/lib/widgets/pages/settings/settings_page.dart
@@ -157,10 +157,11 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
     );
   }
 
-  Widget _buildExcludedTermItem(List<ExcludedTerm> terms, int index) {
+  Widget _buildExcludedTermItem(List<ExcludedTerm> terms, int index, BoxDecoration? decoration) {
     final term = terms[index];
 
     return EditExcludedTermInputField(
+      decoration: decoration,
       delegate: excludedTermsDelegate,
       index: index,
       excludedTerm: term,
@@ -195,6 +196,11 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
           ),
           initialData: excludedTermsDelegate.terms,
           stream: excludedTermsDelegate.stream,
+          separatorBuilder: (context, index) => Container(
+            color: excludedTermDivider.color,
+            height: excludedTermDivider.width,
+            margin: const EdgeInsetsDirectional.only(start: 15.0),
+          ),
           builder: (items, index) {
             BorderRadius borderRadius = BorderRadius.zero;
 
@@ -205,21 +211,12 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
               );
             }
 
-            return DecoratedBox(
-              decoration: BoxDecoration(
+            return _buildExcludedTermItem(
+              items,
+              index,
+              BoxDecoration(
                 borderRadius: borderRadius,
                 color: CupertinoColors.secondarySystemGroupedBackground,
-              ),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Container(
-                    color: excludedTermDivider.color,
-                    height: excludedTermDivider.width,
-                    margin: const EdgeInsetsDirectional.only(start: 15.0),
-                  ),
-                  _buildExcludedTermItem(items, index),
-                ],
               ),
             );
           },

--- a/lib/widgets/pages/settings/settings_page.dart
+++ b/lib/widgets/pages/settings/settings_page.dart
@@ -190,6 +190,11 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
               ),
               color: CupertinoColors.secondarySystemGroupedBackground,
             ),
+            bottom: Container(
+              color: excludedTermDivider.color,
+              height: excludedTermDivider.width,
+              margin: const EdgeInsetsDirectional.only(start: 15.0),
+            ),
             delegate: excludedTermsDelegate,
             focusNode: addTermFocusNode,
             formKey: addTermFormKey,


### PR DESCRIPTION
This PR cleans up a few things with the excluded term input field:
- the `DecoratedBox` has moved to inside the `ExcludedTermInputField`
- the button bar no longer uses `MainAxisSize.min`
- the `ExcludedTermsList` now computes the correct semantics indexes
- the `ExcludedTermInputField` now internally handles a `context menu` like widget

Part of #206 