### PR TITLE
Media query fixes

### DIFF
--- a/lib/widgets/common/generic_error.dart
+++ b/lib/widgets/common/generic_error.dart
@@ -46,7 +46,7 @@ class GenericError extends StatelessWidget {
         PlatformAwareIcon(
           androidIcon: androidIcon ?? Icons.warning,
           iosIcon: iosIcon ?? CupertinoIcons.exclamationmark_triangle_fill,
-          size: MediaQuery.of(context).size.shortestSide * .1,
+          size: MediaQuery.sizeOf(context).shortestSide * .1,
         ),
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),

--- a/lib/widgets/common/rider_search_filter_empty.dart
+++ b/lib/widgets/common/rider_search_filter_empty.dart
@@ -14,7 +14,7 @@ class RiderSearchFilterEmpty extends StatelessWidget {
         PlatformAwareIcon(
           androidIcon: Icons.people,
           iosIcon: CupertinoIcons.person_2_fill,
-          size: MediaQuery.of(context).size.shortestSide * .1,
+          size: MediaQuery.sizeOf(context).shortestSide * .1,
         ),
         Padding(
           padding: const EdgeInsets.only(top: 4, left: 16, right: 16),

--- a/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
@@ -34,7 +34,7 @@ class _GenericScanErrorBase extends StatelessWidget {
       children: [
         IconTheme(
           data: IconThemeData(
-            size: MediaQuery.of(context).size.shortestSide * .1,
+            size: MediaQuery.sizeOf(context).shortestSide * .1,
           ),
           child: icon,
         ),

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_empty.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_empty.dart
@@ -18,7 +18,7 @@ class ManualSelectionListEmpty extends StatelessWidget {
         PlatformAwareIcon(
           androidIcon: Icons.people,
           iosIcon: CupertinoIcons.person_2_fill,
-          size: MediaQuery.of(context).size.shortestSide * .1,
+          size: MediaQuery.sizeOf(context).shortestSide * .1,
         ),
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 4, 16, 20),

--- a/lib/widgets/pages/ride_details/ride_details_attendees/ride_details_attendees_list_empty.dart
+++ b/lib/widgets/pages/ride_details/ride_details_attendees/ride_details_attendees_list_empty.dart
@@ -15,7 +15,7 @@ class RideDetailsAttendeesListEmpty extends StatelessWidget {
           PlatformAwareIcon(
             androidIcon: Icons.people,
             iosIcon: CupertinoIcons.person_2_fill,
-            size: MediaQuery.of(context).size.shortestSide * .1,
+            size: MediaQuery.sizeOf(context).shortestSide * .1,
           ),
           Padding(
             padding: const EdgeInsets.only(top: 4),

--- a/lib/widgets/pages/ride_list/ride_list_empty.dart
+++ b/lib/widgets/pages/ride_list/ride_list_empty.dart
@@ -14,7 +14,7 @@ class RideListEmpty extends StatelessWidget {
           PlatformAwareIcon(
             androidIcon: Icons.directions_bike,
             iosIcon: Icons.directions_bike,
-            size: MediaQuery.of(context).size.shortestSide * .1,
+            size: MediaQuery.sizeOf(context).shortestSide * .1,
           ),
           Padding(
             padding: const EdgeInsets.only(top: 4, right: 16, left: 16),

--- a/lib/widgets/pages/rider_list/rider_list_empty.dart
+++ b/lib/widgets/pages/rider_list/rider_list_empty.dart
@@ -14,7 +14,7 @@ class RiderListEmpty extends StatelessWidget {
         PlatformAwareIcon(
           androidIcon: Icons.people,
           iosIcon: CupertinoIcons.person_2_fill,
-          size: MediaQuery.of(context).size.shortestSide * .1,
+          size: MediaQuery.sizeOf(context).shortestSide * .1,
         ),
         Padding(
           padding: const EdgeInsets.only(top: 4, left: 16, right: 16),

--- a/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field.dart
@@ -193,7 +193,7 @@ class _EditExcludedTermInputFieldState extends State<EditExcludedTermInputField>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final EdgeInsets viewInsets = MediaQuery.of(context).viewInsets;
+    final EdgeInsets viewInsets = MediaQuery.viewInsetsOf(context);
 
     // If the bottom view insets collapsed back to zero, notify the waiting view insets completer.
     if (_viewInsetsHiddenCompleter == null || _viewInsetsHiddenCompleter!.isCompleted) {

--- a/lib/widgets/pages/settings/settings_page.dart
+++ b/lib/widgets/pages/settings/settings_page.dart
@@ -179,7 +179,7 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
     final translator = S.of(context);
     final excludedTermDivider = BorderSide(
       color: CupertinoColors.separator.resolveFrom(context),
-      width: 1.0 / MediaQuery.of(context).devicePixelRatio,
+      width: 1.0 / MediaQuery.devicePixelRatioOf(context),
     );
 
     return SettingsPageScrollView(

--- a/lib/widgets/platform/cupertino_bottom_bar.dart
+++ b/lib/widgets/platform/cupertino_bottom_bar.dart
@@ -29,7 +29,7 @@ class CupertinoBottomBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final double bottomPadding = MediaQuery.of(context).padding.bottom;
+    final double bottomPadding = MediaQuery.paddingOf(context).bottom;
     final Color backgroundColor = CupertinoTheme.of(context).barBackgroundColor;
 
     const border = Border(


### PR DESCRIPTION
This PR optimizes the various `MediaQuery.of(context)` usages to refer to the aspect variants.
It also fixes a bug where the excluded term input field did not account for the presence of a hardware keyboard (which would result in the `viewInsets.bottom` already being zero)