### PR TITLE
iOS Dark theme support

### DIFF
--- a/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
+++ b/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
@@ -298,12 +298,10 @@ class RideAttendeeScanningDelegate {
         // If the device has multiple possible owners,
         // add the conflicting owners to the unresolved owners.
         _unresolvedOwners.addAll(owners);
-
-        return;
+      } else {
+        // Otherwise the single owner can be resolved automatically.
+        _addRideAttendee(owners.first.uuid, isScanned: true);
       }
-
-      // Otherwise the single owner can be resolved automatically.
-      _addRideAttendee(owners.first.uuid, isScanned: true);
     }
 
     // Finally, add the device to the list of found devices and emit the device found signal.

--- a/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
+++ b/lib/model/ride_attendee_scanning/ride_attendee_scanning_delegate.dart
@@ -374,6 +374,9 @@ class RideAttendeeScanningDelegate {
     _scrollToManualSelectionLabel();
   }
 
+  /// Get the amount of scanned peripherals.
+  int get scannedPeripheralsLength => _devicesWithOwners.length;
+
   /// Get the scanned Bluetooth peripheral at the given [index].
   BluetoothPeripheralWithOwners getScannedPeripheral(int index) => _devicesWithOwners[index];
 

--- a/lib/widgets/custom/add_ride_calendar/add_ride_calendar_color_legend.dart
+++ b/lib/widgets/custom/add_ride_calendar/add_ride_calendar_color_legend.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/widgets/theme.dart' show RideCalendarTheme;
 
@@ -27,12 +27,14 @@ class AddRideCalendarColorLegend extends StatelessWidget {
     required AxisDirection dotDirection,
     required String label,
   }) {
-    final dot = Container(
-      height: dotSize,
-      width: dotSize,
-      decoration: BoxDecoration(
-        borderRadius: const BorderRadius.all(Radius.circular(10)),
-        color: color,
+    final dot = Builder(
+      builder: (context) => Container(
+        height: dotSize,
+        width: dotSize,
+        decoration: BoxDecoration(
+          borderRadius: const BorderRadius.all(Radius.circular(10)),
+          color: color is CupertinoDynamicColor ? color.resolveFrom(context) : color,
+        ),
       ),
     );
 

--- a/lib/widgets/custom/add_ride_calendar/add_ride_calendar_item.dart
+++ b/lib/widgets/custom/add_ride_calendar/add_ride_calendar_item.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:weforza/model/add_ride_page_delegate.dart';
 import 'package:weforza/widgets/theme.dart' show RideCalendarTheme;
@@ -59,6 +60,12 @@ class AddRideCalendarItem extends StatelessWidget {
       initialData: delegate.currentSelection,
       stream: delegate.selectionStream,
       builder: (context, _) {
+        Color? backgroundColor = _computeBackgroundColor();
+
+        if (backgroundColor is CupertinoDynamicColor) {
+          backgroundColor = backgroundColor.resolveFrom(context);
+        }
+
         return GestureDetector(
           onTap: () => delegate.selectDay(date),
           child: SizedBox.fromSize(
@@ -67,7 +74,7 @@ class AddRideCalendarItem extends StatelessWidget {
               padding: theme.padding,
               child: DecoratedBox(
                 decoration: BoxDecoration(
-                  color: _computeBackgroundColor(),
+                  color: backgroundColor,
                   borderRadius: const BorderRadius.all(Radius.circular(4)),
                 ),
                 child: Center(

--- a/lib/widgets/custom/profile_image/profile_image_picker_placeholder.dart
+++ b/lib/widgets/custom/profile_image/profile_image_picker_placeholder.dart
@@ -15,45 +15,48 @@ class CupertinoProfileImagePickerPlaceholder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox.square(
-      dimension: size,
-      child: Stack(
-        children: [
-          Container(
-            width: size,
-            height: size,
-            decoration: BoxDecoration(
-              color: CupertinoColors.systemGrey2,
-              borderRadius: BorderRadius.all(
-                Radius.circular(size / 2),
-              ),
-            ),
-          ),
-          Align(
-            alignment: Alignment.bottomCenter,
-            child: Transform.translate(
-              offset: Offset(0, size / 10),
-              child: Icon(
-                CupertinoIcons.person_solid,
-                color: CupertinoColors.white,
-                size: size,
-              ),
-            ),
-          ),
-          Container(
-            width: size,
-            height: size,
-            decoration: BoxDecoration(
-              border: Border.all(
+    return ClipRRect(
+      borderRadius: BorderRadius.all(Radius.circular(size / 2)),
+      child: SizedBox.square(
+        dimension: size,
+        child: Stack(
+          children: [
+            Container(
+              width: size,
+              height: size,
+              decoration: BoxDecoration(
                 color: CupertinoColors.systemGrey2,
-                width: 3.0,
-              ),
-              borderRadius: BorderRadius.all(
-                Radius.circular(size / 2),
+                borderRadius: BorderRadius.all(
+                  Radius.circular(size / 2),
+                ),
               ),
             ),
-          ),
-        ],
+            Align(
+              alignment: Alignment.bottomCenter,
+              child: Transform.translate(
+                offset: Offset(0, size / 10),
+                child: Icon(
+                  CupertinoIcons.person_solid,
+                  color: CupertinoColors.white,
+                  size: size,
+                ),
+              ),
+            ),
+            Container(
+              width: size,
+              height: size,
+              decoration: BoxDecoration(
+                border: Border.all(
+                  color: CupertinoColors.systemGrey2,
+                  width: 3.0,
+                ),
+                borderRadius: BorderRadius.all(
+                  Radius.circular(size / 2),
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/pages/add_ride_page.dart
+++ b/lib/widgets/pages/add_ride_page.dart
@@ -181,7 +181,10 @@ class _AddRideSubmitButton extends StatelessWidget {
             ),
             ios: (_) => CupertinoButton.filled(
               onPressed: hasSelection ? onPressed : null,
-              child: Text(translator.addSelection),
+              child: Text(
+                translator.addSelection,
+                style: TextStyle(color: hasSelection ? CupertinoColors.white : CupertinoColors.inactiveGray),
+              ),
             ),
           );
         },

--- a/lib/widgets/pages/import_riders_page.dart
+++ b/lib/widgets/pages/import_riders_page.dart
@@ -201,9 +201,9 @@ class _ImportRidersButton extends StatelessWidget {
                     children: [
                       const Padding(
                         padding: EdgeInsets.only(right: 8),
-                        child: Icon(CupertinoIcons.arrow_down_doc),
+                        child: Icon(CupertinoIcons.arrow_down_doc, color: CupertinoColors.white),
                       ),
-                      Text(label),
+                      Text(label, style: const TextStyle(color: CupertinoColors.white)),
                     ],
                   ),
                 ),

--- a/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
@@ -91,7 +91,7 @@ class BluetoothDisabledError extends StatelessWidget {
         ),
         ios: (_) => CupertinoButton.filled(
           onPressed: AppSettings.openBluetoothSettings,
-          child: Text(translator.goToSettings),
+          child: Text(translator.goToSettings, style: const TextStyle(color: CupertinoColors.white)),
         ),
       ),
       secondaryButton: PlatformAwareWidget(
@@ -127,7 +127,7 @@ class GenericScanError extends StatelessWidget {
           onPressed: () => Navigator.of(context).pop(),
         ),
         ios: (context) => CupertinoButton.filled(
-          child: Text(translator.goBackToDetailPage),
+          child: Text(translator.goBackToDetailPage, style: const TextStyle(color: CupertinoColors.white)),
           onPressed: () => Navigator.of(context).pop(),
         ),
       ),
@@ -158,7 +158,7 @@ class PermissionDeniedError extends StatelessWidget {
         ),
         ios: (_) => CupertinoButton.filled(
           onPressed: AppSettings.openAppSettings,
-          child: Text(translator.goToSettings),
+          child: Text(translator.goToSettings, style: const TextStyle(color: CupertinoColors.white)),
         ),
       ),
       secondaryButton: PlatformAwareWidget(

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_bottom_bar.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_bottom_bar.dart
@@ -107,12 +107,20 @@ class ManualSelectionBottomBar extends StatelessWidget {
   }
 
   Widget _buildIosLayout(BuildContext context, BoxConstraints constraints) {
+    final labelTextStyle = TextStyle(
+      color: const CupertinoDynamicColor.withBrightness(
+        color: CupertinoColors.label,
+        darkColor: CupertinoColors.white,
+      ).resolveFrom(context),
+      fontSize: 15,
+    );
+
     final attendeeCounter = _buildAttendeeCounter(
       const Icon(
         CupertinoIcons.person_2_fill,
         color: CupertinoColors.activeBlue,
       ),
-      textStyle: const TextStyle(color: CupertinoColors.label, fontSize: 15),
+      textStyle: labelTextStyle,
     );
 
     final scannedResultsToggle = Row(
@@ -123,7 +131,7 @@ class ManualSelectionBottomBar extends StatelessWidget {
           maxLines: 2,
           overflow: TextOverflow.ellipsis,
           softWrap: true,
-          style: const TextStyle(color: CupertinoColors.label, fontSize: 15),
+          style: labelTextStyle,
           textAlign: TextAlign.right,
         ),
         showScannedResultsToggle,

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_empty.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_list_empty.dart
@@ -33,7 +33,7 @@ class ManualSelectionListEmpty extends StatelessWidget {
             onPressed: () => Navigator.of(context).pop(),
           ),
           ios: (context) => CupertinoButton.filled(
-            child: Text(translator.goBack),
+            child: Text(translator.goBack, style: const TextStyle(color: CupertinoColors.white)),
             onPressed: () => Navigator.of(context).pop(),
           ),
         ),

--- a/lib/widgets/pages/ride_attendee_scanning_page/scan_button.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/scan_button.dart
@@ -31,7 +31,7 @@ class ScanButton extends StatelessWidget {
           padding: const EdgeInsets.symmetric(vertical: 16),
           child: CupertinoButton.filled(
             onPressed: onPressed,
-            child: Text(text),
+            child: Text(text, style: const TextStyle(color: CupertinoColors.white)),
           ),
         ),
       ),

--- a/lib/widgets/pages/ride_attendee_scanning_page/scan_progress_indicator.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/scan_progress_indicator.dart
@@ -21,14 +21,6 @@ class ScanProgressIndicator extends StatelessWidget {
   /// The stream of changes to the scanning state.
   final Stream<bool> isScanningStream;
 
-  Widget _buildProgressIndicator(double progress, Color color) {
-    return LinearProgressIndicator(
-      backgroundColor: color.withOpacity(0.4),
-      value: progress,
-      valueColor: AlwaysStoppedAnimation<Color>(color),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<bool>(
@@ -51,20 +43,69 @@ class ScanProgressIndicator extends StatelessWidget {
                 final progress = animationController.value;
 
                 return PlatformAwareWidget(
-                  android: (_) => _buildProgressIndicator(
-                    progress,
-                    Colors.green,
+                  android: (_) => _BrightnessAwareProgressIndicator(
+                    progress: progress,
+                    color: Colors.green,
+                    backgroundColor: Colors.green.withOpacity(0.4),
                   ),
-                  ios: (_) => _buildProgressIndicator(
-                    progress,
-                    CupertinoColors.systemGreen,
-                  ),
+                  ios: (context) {
+                    final theme = CupertinoTheme.of(context);
+
+                    return _BrightnessAwareProgressIndicator(
+                      progress: progress,
+                      color: theme.primaryColor,
+                      backgroundColor: CupertinoColors.white,
+                      darkBackgroundColor: CupertinoColors.inactiveGray,
+                    );
+                  },
                 );
               },
             ),
           ),
         );
       },
+    );
+  }
+}
+
+class _BrightnessAwareProgressIndicator extends StatelessWidget {
+  const _BrightnessAwareProgressIndicator({
+    required this.backgroundColor,
+    required this.color,
+    required this.progress,
+    this.darkBackgroundColor,
+  });
+
+  /// The background color when the brightness is [Brightness.light].
+  final Color backgroundColor;
+
+  /// The background color when the brightness is [Brightness.dark].
+  /// If this is null, defaults to [backgroundColor].
+  final Color? darkBackgroundColor;
+
+  /// The color for the progress.
+  final Color color;
+
+  /// The progress value.
+  final double progress;
+
+  @override
+  Widget build(BuildContext context) {
+    Color effectiveBackgroundColor;
+
+    switch (MediaQuery.platformBrightnessOf(context)) {
+      case Brightness.dark:
+        effectiveBackgroundColor = darkBackgroundColor ?? backgroundColor;
+        break;
+      case Brightness.light:
+        effectiveBackgroundColor = backgroundColor;
+        break;
+    }
+
+    return LinearProgressIndicator(
+      backgroundColor: effectiveBackgroundColor,
+      value: progress,
+      valueColor: AlwaysStoppedAnimation<Color>(color),
     );
   }
 }

--- a/lib/widgets/pages/ride_attendee_scanning_page/scan_results_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/scan_results_list.dart
@@ -36,6 +36,7 @@ class ScanResultsList extends StatelessWidget {
         Expanded(
           child: AnimatedList(
             key: scanResultsListKey,
+            initialItemCount: delegate.scannedPeripheralsLength,
             itemBuilder: (context, index, animation) {
               return SizeTransition(
                 sizeFactor: animation,

--- a/lib/widgets/pages/ride_attendee_scanning_page/scan_results_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/scan_results_list.dart
@@ -94,7 +94,8 @@ class _ScanResultsListItem extends StatelessWidget {
             padding: const EdgeInsets.only(left: 4),
             child: Text(
               S.of(context).amountOfRidersWithDeviceName(peripheral.owners.length),
-              style: TextStyle(fontStyle: FontStyle.italic, fontSize: 12, color: color),
+              style: TextStyle(fontStyle: FontStyle.italic, fontSize: 14, color: color),
+              maxLines: 2,
             ),
           ),
         ],

--- a/lib/widgets/pages/ride_attendee_scanning_page/unresolved_owners_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/unresolved_owners_list.dart
@@ -51,11 +51,18 @@ class _UnresolvedOwnersListState extends State<UnresolvedOwnersList> {
         break;
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
-        color = CupertinoColors.systemGrey;
+        color = const CupertinoDynamicColor.withBrightness(
+          color: CupertinoColors.systemGrey,
+          darkColor: CupertinoColors.white,
+        );
         break;
     }
 
-    return TextStyle(fontStyle: FontStyle.italic, fontSize: 12, color: color);
+    return TextStyle(
+      fontStyle: FontStyle.italic,
+      fontSize: 14,
+      color: color is CupertinoDynamicColor ? color.resolveFrom(context) : color,
+    );
   }
 
   @override

--- a/lib/widgets/pages/rider_details/rider_devices_list/rider_devices_list.dart
+++ b/lib/widgets/pages/rider_details/rider_devices_list/rider_devices_list.dart
@@ -82,7 +82,7 @@ class _RiderDevicesListState extends ConsumerState<RiderDevicesList> {
 
                   onAddDevicePressed(context, selectedRider!.uuid);
                 },
-                child: Text(S.of(context).addDevice),
+                child: Text(S.of(context).addDevice, style: const TextStyle(color: CupertinoColors.white)),
               ),
             ),
           ),

--- a/lib/widgets/pages/rider_details/rider_devices_list/rider_devices_list_empty.dart
+++ b/lib/widgets/pages/rider_details/rider_devices_list/rider_devices_list_empty.dart
@@ -56,7 +56,7 @@ class RiderDevicesListEmpty extends StatelessWidget {
 
                         onAddDevicePressed(context, selectedRider!.uuid);
                       },
-                      child: Text(translator.addDevice),
+                      child: Text(translator.addDevice, style: const TextStyle(color: CupertinoColors.white)),
                     ),
                   );
                 },

--- a/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field_button_bar.dart
+++ b/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field_button_bar.dart
@@ -81,8 +81,11 @@ class EditExcludedTermInputFieldButtonBar extends StatelessWidget {
             icon: const Icon(Icons.undo),
             onPressed: currentValue == term ? null : onUndoPressed,
           ),
-          ios: (_) => CupertinoIconButton(
-            color: CupertinoColors.black,
+          ios: (context) => CupertinoIconButton(
+            color: const CupertinoDynamicColor.withBrightness(
+              color: CupertinoColors.black,
+              darkColor: CupertinoColors.white,
+            ).resolveFrom(context),
             icon: CupertinoIcons.arrow_counterclockwise,
             onPressed: currentValue == term ? null : onUndoPressed,
           ),

--- a/lib/widgets/pages/settings/excluded_terms/excluded_terms_list_empty.dart
+++ b/lib/widgets/pages/settings/excluded_terms/excluded_terms_list_empty.dart
@@ -24,20 +24,17 @@ class ExcludedTermsListEmpty extends StatelessWidget {
         final textStyle = CupertinoTheme.of(context).textTheme.textStyle;
 
         return Container(
-          decoration: const BoxDecoration(
-            borderRadius: BorderRadius.only(
+          decoration: BoxDecoration(
+            borderRadius: const BorderRadius.only(
               bottomLeft: Radius.circular(10),
               bottomRight: Radius.circular(10),
             ),
-            color: CupertinoColors.secondarySystemGroupedBackground,
+            color: CupertinoColors.secondarySystemGroupedBackground.resolveFrom(context),
           ),
           padding: const EdgeInsets.all(4),
           child: Text(
             text,
-            style: textStyle.copyWith(
-              fontSize: 13,
-              color: CupertinoColors.systemGrey,
-            ),
+            style: textStyle.copyWith(fontSize: 13),
             textAlign: TextAlign.center,
           ),
         );

--- a/lib/widgets/pages/settings/settings_page.dart
+++ b/lib/widgets/pages/settings/settings_page.dart
@@ -275,12 +275,7 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
           children: [
             CupertinoFormRow(
               prefix: Text(translator.version),
-              child: AppVersion(
-                builder: (version) => Text(
-                  version,
-                  style: const TextStyle(color: CupertinoColors.systemGrey),
-                ),
-              ),
+              child: const AppVersion(builder: Text.new),
             ),
           ],
         ),

--- a/lib/widgets/pages/settings/settings_page.dart
+++ b/lib/widgets/pages/settings/settings_page.dart
@@ -182,6 +182,8 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
       width: 1.0 / MediaQuery.devicePixelRatioOf(context),
     );
 
+    final decorationBackgroundColor = CupertinoColors.secondarySystemGroupedBackground.resolveFrom(context);
+
     return SettingsPageScrollView(
       scrollController: scrollController,
       excludedTermsList: SliverPadding(
@@ -189,12 +191,9 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
         sliver: ExcludedTermsList(
           addTermInputField: AddExcludedTermInputField(
             controller: addTermController,
-            decoration: const BoxDecoration(
-              borderRadius: BorderRadius.only(
-                topLeft: Radius.circular(10),
-                topRight: Radius.circular(10),
-              ),
-              color: CupertinoColors.secondarySystemGroupedBackground,
+            decoration: BoxDecoration(
+              borderRadius: const BorderRadius.only(topLeft: Radius.circular(10), topRight: Radius.circular(10)),
+              color: decorationBackgroundColor,
             ),
             delegate: excludedTermsDelegate,
             focusNode: addTermFocusNode,
@@ -215,10 +214,7 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
             return _buildExcludedTermItem(
               items,
               index,
-              decoration: BoxDecoration(
-                borderRadius: borderRadius,
-                color: CupertinoColors.secondarySystemGroupedBackground,
-              ),
+              decoration: BoxDecoration(borderRadius: borderRadius, color: decorationBackgroundColor),
               divider: Container(
                 color: excludedTermDivider.color,
                 height: excludedTermDivider.width,

--- a/lib/widgets/platform/cupertino_icon_button.dart
+++ b/lib/widgets/platform/cupertino_icon_button.dart
@@ -38,7 +38,9 @@ class CupertinoIconButton extends StatelessWidget {
       padding: EdgeInsets.zero,
       child: Icon(
         icon,
-        color: onPressed == null ? CupertinoColors.placeholderText : color ?? CupertinoTheme.of(context).primaryColor,
+        color: onPressed == null
+            ? CupertinoColors.placeholderText.resolveFrom(context)
+            : color ?? CupertinoTheme.of(context).primaryColor,
       ),
     );
   }

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -142,9 +142,15 @@ class RideCalendarTheme {
         return RideCalendarTheme._(
           futureRide: primaryColor.withOpacity(0.4),
           padding: padding,
-          pastDay: CupertinoColors.systemGrey4,
-          pastRide: CupertinoColors.inactiveGray,
           selection: primaryColor,
+          pastDay: const CupertinoDynamicColor.withBrightness(
+            color: CupertinoColors.systemGrey4,
+            darkColor: CupertinoColors.systemGrey,
+          ),
+          pastRide: CupertinoDynamicColor.withBrightness(
+            color: CupertinoColors.systemGrey,
+            darkColor: CupertinoColors.systemGrey4.darkColor,
+          ),
         );
     }
   }


### PR DESCRIPTION
This PR adds the following fixes:

- fix a regression in the display of unresolved devices in the scan results
- update the unresolved owners list description font size
- add the initial item count for the scan results animated list
- add max lines 2 & fontSize 14 to the unresolved owners label in the scan result item

iOS Dark Mode specific changes:
- resolve add ride page colors against brightness
- adjust ride calendar theme colors for Dark Mode
- add explicit white color to CupertinoButton.filled text children
- fix a clipping issue for the image picker placeholder
- adjust the label color for the add ride page submit button
- resolve label colors against brightness for the manual selection bottom bar
- resolve the scanning progress indicator colors against the brightness
- resolve the disabled color for a `CupertinoIconButton` against the brightness
- resolve the label color for the unresolved owners conflict screen description label
- adjust the app version number color
- fix the excluded term list background color & empty list label color
- resolve the excluded. term button bar undo button color against the brightness

Part of #343 