### PR TITLE
Form scrolling fixes

### DIFF
--- a/lib/widgets/pages/device_form.dart
+++ b/lib/widgets/pages/device_form.dart
@@ -9,6 +9,7 @@ import 'package:weforza/model/device/device_model.dart';
 import 'package:weforza/model/device/device_type.dart';
 import 'package:weforza/model/device/device_validator.dart';
 import 'package:weforza/riverpod/rider/selected_rider_devices_provider.dart';
+import 'package:weforza/widgets/common/focus_absorber.dart';
 import 'package:weforza/widgets/common/form_submit_button.dart';
 import 'package:weforza/widgets/common/generic_error.dart';
 import 'package:weforza/widgets/custom/device_type_carousel.dart';
@@ -91,28 +92,30 @@ class DeviceFormState extends ConsumerState<DeviceForm> with DeviceValidator {
           widget.device == null ? translator.addDevice : translator.editDevice,
         ),
       ),
-      body: CustomScrollView(
-        slivers: [
-          SliverList(
-            delegate: SliverChildListDelegate.fixed([
-              Padding(
-                padding: const EdgeInsets.all(16),
-                child: DeviceTypeCarousel(
-                  controller: _deviceTypeController,
-                  height: 120,
+      body: FocusAbsorber(
+        child: CustomScrollView(
+          slivers: [
+            SliverList(
+              delegate: SliverChildListDelegate.fixed([
+                Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: DeviceTypeCarousel(
+                    controller: _deviceTypeController,
+                    height: 120,
+                  ),
                 ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: _buildDeviceNameInput(context),
-              ),
-              Padding(
-                padding: const EdgeInsets.only(top: 16, bottom: 24),
-                child: Center(child: _buildSubmitButton(context)),
-              ),
-            ]),
-          ),
-        ],
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: _buildDeviceNameInput(context),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 16, bottom: 24),
+                  child: Center(child: _buildSubmitButton(context)),
+                ),
+              ]),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -137,30 +140,32 @@ class DeviceFormState extends ConsumerState<DeviceForm> with DeviceValidator {
       ),
       child: SafeArea(
         bottom: false,
-        child: CustomScrollView(
-          slivers: [
-            SliverList(
-              delegate: SliverChildListDelegate.fixed([
-                CupertinoFormSection.insetGrouped(
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: DeviceTypeCarousel(
-                        controller: _deviceTypeController,
-                        height: 120,
+        child: FocusAbsorber(
+          child: CustomScrollView(
+            slivers: [
+              SliverList(
+                delegate: SliverChildListDelegate.fixed([
+                  CupertinoFormSection.insetGrouped(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: DeviceTypeCarousel(
+                          controller: _deviceTypeController,
+                          height: 120,
+                        ),
                       ),
-                    ),
-                  ],
-                ),
-                CupertinoFormSection.insetGrouped(
-                  children: [
-                    _buildDeviceNameInput(context),
-                    _buildSubmitButton(context),
-                  ],
-                ),
-              ]),
-            ),
-          ],
+                    ],
+                  ),
+                  CupertinoFormSection.insetGrouped(
+                    children: [
+                      _buildDeviceNameInput(context),
+                      _buildSubmitButton(context),
+                    ],
+                  ),
+                ]),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/pages/device_form.dart
+++ b/lib/widgets/pages/device_form.dart
@@ -85,7 +85,7 @@ class DeviceFormState extends ConsumerState<DeviceForm> with DeviceValidator {
     final translator = S.of(context);
 
     return Scaffold(
-      resizeToAvoidBottomInset: false,
+      resizeToAvoidBottomInset: true,
       appBar: AppBar(
         title: Text(
           widget.device == null ? translator.addDevice : translator.editDevice,
@@ -127,7 +127,6 @@ class DeviceFormState extends ConsumerState<DeviceForm> with DeviceValidator {
 
     return CupertinoPageScaffold(
       backgroundColor: backgroundColor,
-      resizeToAvoidBottomInset: false,
       navigationBar: CupertinoNavigationBar(
         backgroundColor: backgroundColor,
         border: null,

--- a/lib/widgets/pages/export_data_page/export_data_page.dart
+++ b/lib/widgets/pages/export_data_page/export_data_page.dart
@@ -181,9 +181,11 @@ class ExportDataPage<T> extends StatelessWidget {
         body: _buildBody(
           builder: (context, {bool isExporting = false}) => _buildAndroidForm(
             context,
-            child: isExporting
-                ? const FixedHeightSubmitButton.loading()
-                : FixedHeightSubmitButton(label: label, onPressed: () => delegate.exportDataToFile(context, options)),
+            child: Center(
+              child: isExporting
+                  ? const FixedHeightSubmitButton.loading()
+                  : FixedHeightSubmitButton(label: label, onPressed: () => delegate.exportDataToFile(context, options)),
+            ),
           ),
           doneIndicator: doneIndicator,
           genericErrorIndicator: genericErrorIndicator,

--- a/lib/widgets/pages/export_data_page/export_data_page.dart
+++ b/lib/widgets/pages/export_data_page/export_data_page.dart
@@ -57,36 +57,40 @@ class ExportDataPage<T> extends StatelessWidget {
 
     return Padding(
       padding: const EdgeInsets.only(left: 20, right: 20, top: 24),
-      child: Column(
-        children: [
-          ExportDataFileNameTextField<T>(delegate: delegate),
-          Padding(
-            padding: const EdgeInsets.only(top: 32, bottom: 48),
-            child: DirectorySelectionFormField(
-              controller: delegate.directoryController,
-              autovalidateMode: AutovalidateMode.onUserInteraction,
-              validator: (directory) => _validateDirectory(directory, translator),
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.only(bottom: 40),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.only(right: 8),
-                    child: Text(translator.fileFormat, maxLines: 2),
-                  ),
+      child: CustomScrollView(
+        slivers: [
+          SliverList(
+            delegate: SliverChildListDelegate.fixed([
+              ExportDataFileNameTextField<T>(delegate: delegate),
+              Padding(
+                padding: const EdgeInsets.only(top: 32, bottom: 48),
+                child: DirectorySelectionFormField(
+                  controller: delegate.directoryController,
+                  autovalidateMode: AutovalidateMode.onUserInteraction,
+                  validator: (directory) => _validateDirectory(directory, translator),
                 ),
-                ExportFileFormatSelection(
-                  initialValue: delegate.currentFileFormat,
-                  onFormatSelected: delegate.setFileFormat,
-                  stream: delegate.fileFormatStream,
+              ),
+              Padding(
+                padding: const EdgeInsets.only(bottom: 40),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.only(right: 8),
+                        child: Text(translator.fileFormat, maxLines: 2),
+                      ),
+                    ),
+                    ExportFileFormatSelection(
+                      initialValue: delegate.currentFileFormat,
+                      onFormatSelected: delegate.setFileFormat,
+                      stream: delegate.fileFormatStream,
+                    ),
+                  ],
                 ),
-              ],
-            ),
+              ),
+              child,
+            ]),
           ),
-          child,
         ],
       ),
     );
@@ -127,24 +131,32 @@ class ExportDataPage<T> extends StatelessWidget {
   Widget _buildIosForm(BuildContext context, {required Widget child}) {
     final translator = S.of(context);
 
-    return CupertinoFormSection.insetGrouped(
-      children: [
-        ExportDataFileNameTextField<T>(delegate: delegate),
-        DirectorySelectionFormField(
-          controller: delegate.directoryController,
-          autovalidateMode: AutovalidateMode.onUserInteraction,
-          validator: (directory) => _validateDirectory(directory, translator),
+    return CustomScrollView(
+      slivers: [
+        SliverList(
+          delegate: SliverChildListDelegate.fixed([
+            CupertinoFormSection.insetGrouped(
+              children: [
+                ExportDataFileNameTextField<T>(delegate: delegate),
+                DirectorySelectionFormField(
+                  controller: delegate.directoryController,
+                  autovalidateMode: AutovalidateMode.onUserInteraction,
+                  validator: (directory) => _validateDirectory(directory, translator),
+                ),
+                CupertinoFormRow(
+                  padding: const EdgeInsetsDirectional.fromSTEB(20, 20, 6, 20),
+                  prefix: Flexible(child: Text(translator.fileFormat, maxLines: 2)),
+                  child: ExportFileFormatSelection(
+                    initialValue: delegate.currentFileFormat,
+                    onFormatSelected: delegate.setFileFormat,
+                    stream: delegate.fileFormatStream,
+                  ),
+                ),
+                child,
+              ],
+            ),
+          ]),
         ),
-        CupertinoFormRow(
-          padding: const EdgeInsetsDirectional.fromSTEB(20, 20, 6, 20),
-          prefix: Flexible(child: Text(translator.fileFormat, maxLines: 2)),
-          child: ExportFileFormatSelection(
-            initialValue: delegate.currentFileFormat,
-            onFormatSelected: delegate.setFileFormat,
-            stream: delegate.fileFormatStream,
-          ),
-        ),
-        child,
       ],
     );
   }

--- a/lib/widgets/pages/export_data_page/export_data_page.dart
+++ b/lib/widgets/pages/export_data_page/export_data_page.dart
@@ -176,7 +176,7 @@ class ExportDataPage<T> extends StatelessWidget {
 
     return PlatformAwareWidget(
       android: (context) => Scaffold(
-        resizeToAvoidBottomInset: false,
+        resizeToAvoidBottomInset: true,
         appBar: AppBar(title: Text(title)),
         body: _buildBody(
           builder: (context, {bool isExporting = false}) => _buildAndroidForm(
@@ -197,7 +197,6 @@ class ExportDataPage<T> extends StatelessWidget {
 
         return CupertinoPageScaffold(
           backgroundColor: backgroundColor,
-          resizeToAvoidBottomInset: false,
           navigationBar: CupertinoNavigationBar(
             backgroundColor: backgroundColor,
             border: null,

--- a/lib/widgets/pages/rider_form.dart
+++ b/lib/widgets/pages/rider_form.dart
@@ -14,6 +14,7 @@ import 'package:weforza/riverpod/file_handler_provider.dart';
 import 'package:weforza/riverpod/repository/rider_repository_provider.dart';
 import 'package:weforza/riverpod/rider/rider_list_provider.dart';
 import 'package:weforza/riverpod/rider/selected_rider_provider.dart';
+import 'package:weforza/widgets/common/focus_absorber.dart';
 import 'package:weforza/widgets/common/form_submit_button.dart';
 import 'package:weforza/widgets/common/generic_error.dart';
 import 'package:weforza/widgets/custom/profile_image/profile_image_picker.dart';
@@ -155,112 +156,114 @@ class _RiderFormState extends ConsumerState<RiderForm> with RiderValidator {
       ),
       body: Form(
         key: _formKey,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: CustomScrollView(
-            slivers: [
-              SliverList(
-                delegate: SliverChildListDelegate.fixed([
-                  Center(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 16),
-                      child: ProfileImagePicker(
-                        delegate: _profileImageDelegate,
-                        imagePreviewSize: 100,
-                        pickingIndicator: const SizedBox.square(
-                          dimension: 64,
-                          child: Center(child: CircularProgressIndicator()),
+        child: FocusAbsorber(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: CustomScrollView(
+              slivers: [
+                SliverList(
+                  delegate: SliverChildListDelegate.fixed([
+                    Center(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        child: ProfileImagePicker(
+                          delegate: _profileImageDelegate,
+                          imagePreviewSize: 100,
+                          pickingIndicator: const SizedBox.square(
+                            dimension: 64,
+                            child: Center(child: CircularProgressIndicator()),
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 8),
-                    child: TextFormField(
-                      textCapitalization: TextCapitalization.words,
-                      focusNode: _firstNameFocusNode,
-                      textInputAction: TextInputAction.next,
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8),
+                      child: TextFormField(
+                        textCapitalization: TextCapitalization.words,
+                        focusNode: _firstNameFocusNode,
+                        textInputAction: TextInputAction.next,
+                        decoration: InputDecoration(
+                          contentPadding: const EdgeInsets.all(8),
+                          labelText: strings.firstName,
+                          // Prevent popping during validation.
+                          helperText: ' ',
+                        ),
+                        controller: _firstNameController,
+                        autocorrect: false,
+                        keyboardType: TextInputType.text,
+                        onChanged: _resetSubmit,
+                        validator: (value) => validateFirstOrLastName(
+                          value: value,
+                          requiredMessage: strings.firstNameRequired,
+                          maxLengthMessage: strings.firstNameMaxLength(
+                            Rider.nameAndAliasMaxLength,
+                          ),
+                          illegalCharachterMessage: strings.firstNameIllegalCharacters,
+                          isBlankMessage: strings.firstNameBlank,
+                        ),
+                        autovalidateMode: AutovalidateMode.onUserInteraction,
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 4),
+                      child: TextFormField(
+                        textCapitalization: TextCapitalization.words,
+                        focusNode: _lastNameFocusNode,
+                        textInputAction: TextInputAction.next,
+                        decoration: InputDecoration(
+                          contentPadding: const EdgeInsets.all(8),
+                          labelText: strings.lastName,
+                          // Prevent popping during validation.
+                          helperText: ' ',
+                        ),
+                        controller: _lastNameController,
+                        autocorrect: false,
+                        keyboardType: TextInputType.text,
+                        onChanged: _resetSubmit,
+                        validator: (value) => validateFirstOrLastName(
+                          value: value,
+                          requiredMessage: strings.lastNameRequired,
+                          maxLengthMessage: strings.lastNameMaxLength(
+                            Rider.nameAndAliasMaxLength,
+                          ),
+                          illegalCharachterMessage: strings.lastNameIllegalCharacters,
+                          isBlankMessage: strings.lastNameBlank,
+                        ),
+                        autovalidateMode: AutovalidateMode.onUserInteraction,
+                      ),
+                    ),
+                    TextFormField(
+                      focusNode: _aliasFocusNode,
+                      textInputAction: TextInputAction.done,
                       decoration: InputDecoration(
                         contentPadding: const EdgeInsets.all(8),
-                        labelText: strings.firstName,
+                        labelText: strings.alias,
                         // Prevent popping during validation.
                         helperText: ' ',
                       ),
-                      controller: _firstNameController,
+                      controller: _aliasController,
                       autocorrect: false,
                       keyboardType: TextInputType.text,
                       onChanged: _resetSubmit,
-                      validator: (value) => validateFirstOrLastName(
+                      validator: (value) => validateAlias(
                         value: value,
-                        requiredMessage: strings.firstNameRequired,
-                        maxLengthMessage: strings.firstNameMaxLength(
+                        maxLengthMessage: strings.aliasMaxLength(
                           Rider.nameAndAliasMaxLength,
                         ),
-                        illegalCharachterMessage: strings.firstNameIllegalCharacters,
-                        isBlankMessage: strings.firstNameBlank,
+                        illegalCharachterMessage: strings.aliasIllegalCharacters,
+                        isBlankMessage: strings.aliasBlank,
                       ),
                       autovalidateMode: AutovalidateMode.onUserInteraction,
+                      onFieldSubmitted: (value) => _aliasFocusNode.unfocus(),
                     ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 4),
-                    child: TextFormField(
-                      textCapitalization: TextCapitalization.words,
-                      focusNode: _lastNameFocusNode,
-                      textInputAction: TextInputAction.next,
-                      decoration: InputDecoration(
-                        contentPadding: const EdgeInsets.all(8),
-                        labelText: strings.lastName,
-                        // Prevent popping during validation.
-                        helperText: ' ',
-                      ),
-                      controller: _lastNameController,
-                      autocorrect: false,
-                      keyboardType: TextInputType.text,
-                      onChanged: _resetSubmit,
-                      validator: (value) => validateFirstOrLastName(
-                        value: value,
-                        requiredMessage: strings.lastNameRequired,
-                        maxLengthMessage: strings.lastNameMaxLength(
-                          Rider.nameAndAliasMaxLength,
-                        ),
-                        illegalCharachterMessage: strings.lastNameIllegalCharacters,
-                        isBlankMessage: strings.lastNameBlank,
-                      ),
-                      autovalidateMode: AutovalidateMode.onUserInteraction,
+                    Padding(
+                      padding: const EdgeInsets.only(top: 12, bottom: 24),
+                      child: Center(child: _buildSubmitButton(context)),
                     ),
-                  ),
-                  TextFormField(
-                    focusNode: _aliasFocusNode,
-                    textInputAction: TextInputAction.done,
-                    decoration: InputDecoration(
-                      contentPadding: const EdgeInsets.all(8),
-                      labelText: strings.alias,
-                      // Prevent popping during validation.
-                      helperText: ' ',
-                    ),
-                    controller: _aliasController,
-                    autocorrect: false,
-                    keyboardType: TextInputType.text,
-                    onChanged: _resetSubmit,
-                    validator: (value) => validateAlias(
-                      value: value,
-                      maxLengthMessage: strings.aliasMaxLength(
-                        Rider.nameAndAliasMaxLength,
-                      ),
-                      illegalCharachterMessage: strings.aliasIllegalCharacters,
-                      isBlankMessage: strings.aliasBlank,
-                    ),
-                    autovalidateMode: AutovalidateMode.onUserInteraction,
-                    onFieldSubmitted: (value) => _aliasFocusNode.unfocus(),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 12, bottom: 24),
-                    child: Center(child: _buildSubmitButton(context)),
-                  ),
-                ]),
-              ),
-            ],
+                  ]),
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -288,99 +291,101 @@ class _RiderFormState extends ConsumerState<RiderForm> with RiderValidator {
       child: SafeArea(
         child: Form(
           key: _formKey,
-          child: CustomScrollView(
-            slivers: [
-              SliverList(
-                delegate: SliverChildListDelegate.fixed([
-                  CupertinoFormSection.insetGrouped(
-                    children: [
-                      Center(
-                        child: Padding(
-                          padding: const EdgeInsetsDirectional.fromSTEB(20, 6, 6, 6),
-                          child: ProfileImagePicker(
-                            delegate: _profileImageDelegate,
-                            imagePreviewSize: 80,
-                            pickingIndicator: const SizedBox.square(
-                              dimension: 88,
-                              child: Center(
-                                child: CupertinoActivityIndicator(),
+          child: FocusAbsorber(
+            child: CustomScrollView(
+              slivers: [
+                SliverList(
+                  delegate: SliverChildListDelegate.fixed([
+                    CupertinoFormSection.insetGrouped(
+                      children: [
+                        Center(
+                          child: Padding(
+                            padding: const EdgeInsetsDirectional.fromSTEB(20, 6, 6, 6),
+                            child: ProfileImagePicker(
+                              delegate: _profileImageDelegate,
+                              imagePreviewSize: 80,
+                              pickingIndicator: const SizedBox.square(
+                                dimension: 88,
+                                child: Center(
+                                  child: CupertinoActivityIndicator(),
+                                ),
                               ),
                             ),
                           ),
                         ),
-                      ),
-                    ],
-                  ),
-                  CupertinoFormSection.insetGrouped(
-                    children: [
-                      CupertinoTextFormFieldRow(
-                        autovalidateMode: AutovalidateMode.onUserInteraction,
-                        textCapitalization: TextCapitalization.words,
-                        focusNode: _firstNameFocusNode,
-                        textInputAction: TextInputAction.next,
-                        controller: _firstNameController,
-                        maxLength: Rider.nameAndAliasMaxLength,
-                        placeholder: strings.firstName,
-                        keyboardType: TextInputType.text,
-                        onChanged: _resetSubmit,
-                        validator: (value) => validateFirstOrLastName(
-                          value: value,
-                          requiredMessage: strings.firstNameRequired,
-                          maxLengthMessage: strings.firstNameMaxLength(
-                            Rider.nameAndAliasMaxLength,
+                      ],
+                    ),
+                    CupertinoFormSection.insetGrouped(
+                      children: [
+                        CupertinoTextFormFieldRow(
+                          autovalidateMode: AutovalidateMode.onUserInteraction,
+                          textCapitalization: TextCapitalization.words,
+                          focusNode: _firstNameFocusNode,
+                          textInputAction: TextInputAction.next,
+                          controller: _firstNameController,
+                          maxLength: Rider.nameAndAliasMaxLength,
+                          placeholder: strings.firstName,
+                          keyboardType: TextInputType.text,
+                          onChanged: _resetSubmit,
+                          validator: (value) => validateFirstOrLastName(
+                            value: value,
+                            requiredMessage: strings.firstNameRequired,
+                            maxLengthMessage: strings.firstNameMaxLength(
+                              Rider.nameAndAliasMaxLength,
+                            ),
+                            illegalCharachterMessage: strings.firstNameIllegalCharacters,
+                            isBlankMessage: strings.firstNameBlank,
                           ),
-                          illegalCharachterMessage: strings.firstNameIllegalCharacters,
-                          isBlankMessage: strings.firstNameBlank,
                         ),
-                      ),
-                      CupertinoTextFormFieldRow(
-                        autovalidateMode: AutovalidateMode.onUserInteraction,
-                        textCapitalization: TextCapitalization.words,
-                        focusNode: _lastNameFocusNode,
-                        textInputAction: TextInputAction.next,
-                        controller: _lastNameController,
-                        maxLength: Rider.nameAndAliasMaxLength,
-                        placeholder: strings.lastName,
-                        keyboardType: TextInputType.text,
-                        onChanged: _resetSubmit,
-                        validator: (value) => validateFirstOrLastName(
-                          value: value,
-                          requiredMessage: strings.lastNameRequired,
-                          maxLengthMessage: strings.lastNameMaxLength(
-                            Rider.nameAndAliasMaxLength,
+                        CupertinoTextFormFieldRow(
+                          autovalidateMode: AutovalidateMode.onUserInteraction,
+                          textCapitalization: TextCapitalization.words,
+                          focusNode: _lastNameFocusNode,
+                          textInputAction: TextInputAction.next,
+                          controller: _lastNameController,
+                          maxLength: Rider.nameAndAliasMaxLength,
+                          placeholder: strings.lastName,
+                          keyboardType: TextInputType.text,
+                          onChanged: _resetSubmit,
+                          validator: (value) => validateFirstOrLastName(
+                            value: value,
+                            requiredMessage: strings.lastNameRequired,
+                            maxLengthMessage: strings.lastNameMaxLength(
+                              Rider.nameAndAliasMaxLength,
+                            ),
+                            illegalCharachterMessage: strings.lastNameIllegalCharacters,
+                            isBlankMessage: strings.lastNameBlank,
                           ),
-                          illegalCharachterMessage: strings.lastNameIllegalCharacters,
-                          isBlankMessage: strings.lastNameBlank,
                         ),
-                      ),
-                      CupertinoTextFormFieldRow(
-                        autovalidateMode: AutovalidateMode.onUserInteraction,
-                        focusNode: _aliasFocusNode,
-                        textInputAction: TextInputAction.done,
-                        controller: _aliasController,
-                        keyboardType: TextInputType.text,
-                        maxLength: Rider.nameAndAliasMaxLength,
-                        placeholder: strings.alias,
-                        onChanged: _resetSubmit,
-                        validator: (value) => validateAlias(
-                          value: value,
-                          maxLengthMessage: strings.aliasMaxLength(
-                            Rider.nameAndAliasMaxLength,
+                        CupertinoTextFormFieldRow(
+                          autovalidateMode: AutovalidateMode.onUserInteraction,
+                          focusNode: _aliasFocusNode,
+                          textInputAction: TextInputAction.done,
+                          controller: _aliasController,
+                          keyboardType: TextInputType.text,
+                          maxLength: Rider.nameAndAliasMaxLength,
+                          placeholder: strings.alias,
+                          onChanged: _resetSubmit,
+                          validator: (value) => validateAlias(
+                            value: value,
+                            maxLengthMessage: strings.aliasMaxLength(
+                              Rider.nameAndAliasMaxLength,
+                            ),
+                            illegalCharachterMessage: strings.aliasIllegalCharacters,
+                            isBlankMessage: strings.aliasBlank,
                           ),
-                          illegalCharachterMessage: strings.aliasIllegalCharacters,
-                          isBlankMessage: strings.aliasBlank,
+                          onFieldSubmitted: (value) => _aliasFocusNode.unfocus(),
                         ),
-                        onFieldSubmitted: (value) => _aliasFocusNode.unfocus(),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.only(top: 8),
-                        child: _buildSubmitButton(context),
-                      ),
-                    ],
-                  ),
-                ]),
-              ),
-            ],
+                        Padding(
+                          padding: const EdgeInsets.only(top: 8),
+                          child: _buildSubmitButton(context),
+                        ),
+                      ],
+                    ),
+                  ]),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/widgets/pages/rider_form.dart
+++ b/lib/widgets/pages/rider_form.dart
@@ -147,7 +147,7 @@ class _RiderFormState extends ConsumerState<RiderForm> with RiderValidator {
     final strings = S.of(context);
 
     return Scaffold(
-      resizeToAvoidBottomInset: false,
+      resizeToAvoidBottomInset: true,
       appBar: AppBar(
         title: Text(
           widget.rider == null ? strings.newRider : strings.editRider,
@@ -277,7 +277,6 @@ class _RiderFormState extends ConsumerState<RiderForm> with RiderValidator {
 
     return CupertinoPageScaffold(
       backgroundColor: backgroundColor,
-      resizeToAvoidBottomInset: false,
       navigationBar: CupertinoNavigationBar(
         backgroundColor: backgroundColor,
         border: null,


### PR DESCRIPTION
This PR enables `resizeToAvoidBottomInset` on the rider form, device form.
This fixes an issue where those forms would not scroll if the keyboard is shown.
It also adds `FocusAbsorber`s to these forms.

Finally, the export data page now has a scrollview and it also sets `resizeToAvoidBottomInset` to true, to be on par with the other forms.

Fixes #359 