### PR TITLE
Fix suggestion trailing spaces

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -53,7 +53,6 @@
 	"directoryRequired": "A folder is required",
 	"disallowedWordExists": "This disallowed word already exists",
 	"disallowedWordMaxLength": "A disallowed word cannot be longer than {maxLength} characters",
-	"disallowedWordNoWhitespace": "A disallowed word cannot contain spaces",
 	"disallowedWordRequired": "A disallowed word cannot be empty",
 	"disallowedWords": "Disallowed words",
 	"disallowedWordsDescription": "Devices that contain a disallowed word are not shown in the scan results.",

--- a/lib/l10n/intl_nl.arb
+++ b/lib/l10n/intl_nl.arb
@@ -53,7 +53,6 @@
 	"directoryRequired": "Een map is verplicht",
 	"disallowedWordExists": "Dit verboden woord bestaat al",
 	"disallowedWordMaxLength": "Een verboden woord mag niet langer zijn dan {maxLength} karakters",
-	"disallowedWordNoWhitespace": "Een verboden woord mag geen spaties bevatten",
 	"disallowedWordRequired": "Een verboden woord mag niet leeg zijn",
 	"disallowedWords": "Verboden woorden",
 	"disallowedWordsDescription": "Toestellen die een verboden woord bevatten worden niet getoond in de scanresultaten.",

--- a/lib/model/settings/excluded_terms_delegate.dart
+++ b/lib/model/settings/excluded_terms_delegate.dart
@@ -59,8 +59,6 @@ class ExcludedTermsDelegate {
   /// The max length for an excluded term.
   final int maxLength = 16;
 
-  final whitespaceMatcher = RegExp(r'\s');
-
   final SettingsNotifier _settingsDelegate;
 
   /// Get the stream of excluded terms.
@@ -126,7 +124,7 @@ class ExcludedTermsDelegate {
   /// before the `TextEditingValue` changed.
   /// This value is used to prevent a term from being a duplicate of itself.
   ///
-  /// Returns an error message if the value is null, only whitespace or empty.
+  /// Returns an error message if the value is null or empty.
   /// Returns an error message if the value exceeded the [maxLength].
   /// Returns an error message if the value changed from its [originalValue]
   /// and now matches another term in the list of terms, besides itself.
@@ -134,10 +132,6 @@ class ExcludedTermsDelegate {
   String? validateTerm(String? term, S translator, {String? originalValue}) {
     if (term == null || term.isEmpty) {
       return translator.disallowedWordRequired;
-    }
-
-    if (whitespaceMatcher.hasMatch(term)) {
-      return translator.disallowedWordNoWhitespace;
     }
 
     if (term.length > maxLength) {

--- a/lib/widgets/pages/device_form.dart
+++ b/lib/widgets/pages/device_form.dart
@@ -70,7 +70,7 @@ class DeviceFormState extends ConsumerState<DeviceForm> with DeviceValidator {
 
     final model = DeviceModel(
       creationDate: widget.device?.creationDate,
-      name: _deviceNameController.text,
+      name: _deviceNameController.text.trim(),
       ownerId: widget.ownerUuid,
       type: DeviceType.values[selectedDeviceType],
     );

--- a/lib/widgets/pages/rider_form.dart
+++ b/lib/widgets/pages/rider_form.dart
@@ -58,9 +58,9 @@ class _RiderFormState extends ConsumerState<RiderForm> with RiderValidator {
 
     final model = RiderModel(
       active: widget.rider?.active ?? true,
-      alias: _aliasController.text,
-      firstName: _firstNameController.text,
-      lastName: _lastNameController.text,
+      alias: _aliasController.text.trim(),
+      firstName: _firstNameController.text.trim(),
+      lastName: _lastNameController.text.trim(),
       profileImage: _profileImageDelegate.selectedImage.valueOrNull,
       uuid: riderUuid,
     );

--- a/lib/widgets/pages/settings/excluded_terms/excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/excluded_term_input_field.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show MaxLengthEnforcement;
+import 'package:flutter/services.dart' show FilteringTextInputFormatter, MaxLengthEnforcement;
 
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
 
@@ -57,6 +57,11 @@ class ExcludedTermInputField extends StatelessWidget {
   /// The validator function for the text field.
   final String? Function(String? value) validator;
 
+  /// The excluded terms cannot contain spaces.
+  /// To prevent spaces from getting entered through the IME, (from regular typing or from keyboard suggestions),
+  /// filter out whitespace characters.
+  static final inputFormatters = [FilteringTextInputFormatter.deny(RegExp(r'\s'))];
+
   /// Build the invisible counter. The max length is enforced by the text field.
   Widget? _buildAndroidCounter(
     BuildContext context, {
@@ -101,6 +106,7 @@ class ExcludedTermInputField extends StatelessWidget {
         textAlignVertical: TextAlignVertical.center,
         textInputAction: TextInputAction.done,
         validator: validator,
+        inputFormatters: inputFormatters,
       ),
       ios: (_) {
         final child = CupertinoTextFormFieldRow(
@@ -117,6 +123,7 @@ class ExcludedTermInputField extends StatelessWidget {
           placeholder: placeholder,
           textInputAction: TextInputAction.done,
           validator: validator,
+          inputFormatters: inputFormatters,
         );
 
         if (suffix == null) {


### PR DESCRIPTION
Second attempt at fixing #345 

This time, use an input formatter instead. This keeps the suggestions as-is, while still filtering spaces from the IME.
This PR also adds trimming of the values in the rider / device forms.

Fixes #345 