### PR TITLE
Add ride calendar gesture fixes

### DIFF
--- a/lib/model/add_ride_page_delegate.dart
+++ b/lib/model/add_ride_page_delegate.dart
@@ -104,8 +104,8 @@ class AddRidePageDelegate extends AsyncComputationDelegate<void> {
   /// Handle (de)selecting of a day in the calendar.
   void selectDay(DateTime date) {
     // The selection is locked while saving.
-    // Abort if the ride was scheduled in another session.
-    if (_savingSelection || _existingRides.contains(date)) {
+    // Abort if the ride was scheduled in another session, or if the date is in the past.
+    if (_savingSelection || _existingRides.contains(date) || date.isBefore(_today)) {
       return;
     }
 

--- a/lib/widgets/custom/add_ride_calendar/add_ride_calendar_item.dart
+++ b/lib/widgets/custom/add_ride_calendar/add_ride_calendar_item.dart
@@ -67,6 +67,7 @@ class AddRideCalendarItem extends StatelessWidget {
         }
 
         return GestureDetector(
+          behavior: HitTestBehavior.opaque,
           onTap: () => delegate.selectDay(date),
           child: SizedBox.fromSize(size: size, child: Padding(padding: const EdgeInsets.all(4), child: child)),
         );


### PR DESCRIPTION
This PR fixes the add ride calendar not aborting the selection update if the day is in the past. It also fixes the hit test behavior of the button.

Fixes #379 