### PR TITLE
Reland Android namespace

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -66,6 +66,6 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.core:core-splashscreen:1.0.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "androidx.core:core-splashscreen:$splash_screen_version"
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -6,6 +6,3 @@
 -keep class io.flutter.view.**  { *; }
 -keep class io.flutter.**  { *; }
 -keep class io.flutter.plugins.**  { *; }
-
--keepclassmembernames class com.boskokg.flutter_blue_plus.* { *; }
--keep class com.boskokg.flutter_blue_plus.** { *; }

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="be.weforza.app">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
-    package="be.weforza.app">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
 
     <!-- Location permission is required for scanning devices. -->

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="be.weforza.app">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlin_version = '1.7.20'
-    ext.gradle_version = '7.3.1'
+    ext.gradle_version = '7.4.2'
     repositories {
         google()
         mavenCentral()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,9 @@
 buildscript {
-    ext.kotlin_version = '1.7.20'
-    ext.gradle_version = '7.4.2'
+    ext {
+        kotlin_version = '1.7.20'
+        gradle_version = '7.4.2'
+    }
+
     repositories {
         google()
         mavenCentral()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        kotlin_version = '1.7.22'
+        kotlin_version = '1.8.0'
         gradle_version = '7.4.2'
         splash_screen_version = '1.0.1'
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,8 @@
 buildscript {
     ext {
-        kotlin_version = '1.7.20'
+        kotlin_version = '1.7.22'
         gradle_version = '7.4.2'
+        splash_screen_version = '1.0.1'
     }
 
     repositories {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip


### PR DESCRIPTION
This PR relands the removal of the package attribute in the Android Manifest.
It also cleans up some dependencies on the Android side.

Fixes #313 