### PR TITLE
ScopedStorage improvements - Part 1

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
 
+    <!-- This permission is required for using the MediaStore when ScopedStorage is not available. -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />    
+
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
          In most cases you can leave this as-is, but you if you want to provide

--- a/android/app/src/main/kotlin/be/weforza/app/MediaStoreDelegate.kt
+++ b/android/app/src/main/kotlin/be/weforza/app/MediaStoreDelegate.kt
@@ -1,0 +1,162 @@
+package be.weforza.app
+
+import android.content.ContentResolver
+import android.content.ContentValues
+import android.content.Context
+import android.media.MediaScannerConnection
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.annotation.RequiresApi
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel.Result
+import java.io.BufferedReader
+import java.io.File
+import java.io.FileReader
+
+/**
+ * This class provides a delegate to interact with the MediaStore.
+ */
+class MediaStoreDelegate {
+    companion object {
+        const val FILE_DOES_NOT_EXIST_ERROR_CODE = "MEDIA_STORE_FILE_DOES_NOT_EXIST"
+        const val FILE_DOES_NOT_EXIST_ERROR_MESSAGE = "The given file does not exist."
+        const val INSERT_FILE_FAILED_ERROR_CODE = "MEDIA_STORE_INSERT_FILE_FAILED"
+        const val INSERT_FILE_FAILED_ERROR_MESSAGE = "Could not insert a record for the file."
+        const val INVALID_ARGUMENT_ERROR_CODE = "MEDIA_STORE_INVALID_ARGUMENT"
+        const val INVALID_ARGUMENT_ERROR_MESSAGE = "Missing required argument."
+        const val WRITE_FILE_FAILED_ERROR_CODE = "MEDIA_STORE_WRITE_FILE_FAILED"
+        const val WRITE_FILE_FAILED_ERROR_MESSAGE = "Could not write to the output file."
+    }
+
+    /**
+     * Returns whether Scoped Storage is in use.
+     */
+    fun hasScopedStorage() : Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+    }
+
+    /**
+     * Insert a new document in the MediaStore, using a MediaScannerConnection.
+     * The method call arguments should contain a file path and the file MIME-type.
+     *
+     * The result returns with an error if:
+     *  - any required argument is omitted.
+     *  - the MediaStore failed to insert an entry for the document.
+     */
+    fun insertNewDocumentInMediaStore(call: MethodCall, result: Result, context: Context) {
+        val filePath = call.argument<String>("filePath")
+        val fileMimeType = call.argument<String>("fileType")
+
+        if(filePath == null || fileMimeType == null) {
+            result.error(INVALID_ARGUMENT_ERROR_CODE, INVALID_ARGUMENT_ERROR_MESSAGE, null)
+            return
+        }
+
+        val documentFile = File(filePath)
+
+        if(!documentFile.exists()) {
+            result.error(FILE_DOES_NOT_EXIST_ERROR_CODE, FILE_DOES_NOT_EXIST_ERROR_MESSAGE, null)
+            return
+        }
+
+        MediaScannerConnection.scanFile(
+            context,
+            arrayOf(documentFile.absolutePath),
+            arrayOf(fileMimeType)
+        ) { _, uri ->
+            if(uri == null) {
+                result.error(INSERT_FILE_FAILED_ERROR_CODE, INSERT_FILE_FAILED_ERROR_MESSAGE, null)
+            } else {
+                result.success(null)
+            }
+        }
+    }
+
+    /**
+     * Insert a new document in the MediaStore, using ScopedStorage.
+     * The method call arguments should contain a file path, file name, file MIME-type and the file size.
+     *
+     * The result returns with an error if:
+     *  - any required argument is omitted.
+     *  - the MediaStore failed to insert an entry for the document.
+     *  - the MediaStore failed to write the contents to the output file.
+     */
+    @RequiresApi(api = Build.VERSION_CODES.Q)
+    fun insertNewDocumentInMediaStore(
+        call: MethodCall,
+        result: Result,
+        contentResolver: ContentResolver,
+    ) {
+        val filePath = call.argument<String>("filePath")
+        val fileName = call.argument<String>("fileName")
+        val fileMimeType = call.argument<String>("fileType")
+        val fileSize = call.argument<Number>("fileSize")?.toInt()
+
+        if(filePath == null || fileName == null || fileMimeType == null || fileSize == null) {
+            result.error(INVALID_ARGUMENT_ERROR_CODE, INVALID_ARGUMENT_ERROR_MESSAGE, null)
+            return
+        }
+
+        val contentValues = ContentValues()
+        contentValues.put(MediaStore.Files.FileColumns.DISPLAY_NAME, fileName)
+        contentValues.put(MediaStore.Files.FileColumns.TITLE, fileName)
+        contentValues.put(MediaStore.Files.FileColumns.MIME_TYPE, fileMimeType)
+        contentValues.put(MediaStore.Files.FileColumns.SIZE, fileSize)
+        contentValues.put(MediaStore.Files.FileColumns.DATE_ADDED, System.currentTimeMillis())
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            contentValues.put(MediaStore.Files.FileColumns.MEDIA_TYPE, MediaStore.Files.FileColumns.MEDIA_TYPE_DOCUMENT)
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            contentValues.put(MediaStore.Files.FileColumns.RELATIVE_PATH, Environment.DIRECTORY_DOCUMENTS + "/WeForza")
+        } else {
+            contentValues.put(MediaStore.Files.FileColumns.DATA, filePath)
+        }
+
+        val volumeName = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            MediaStore.VOLUME_EXTERNAL
+        } else {
+            "external"
+        }
+
+        var documentUri: Uri? = null
+
+        try {
+            documentUri = contentResolver.insert(MediaStore.Files.getContentUri(volumeName), contentValues)
+        } catch (exception: Exception) {
+            // Fallthrough to handle the null document URI.
+        }
+
+        if(documentUri == null) {
+            result.error(INSERT_FILE_FAILED_ERROR_CODE, INSERT_FILE_FAILED_ERROR_MESSAGE, null)
+            return
+        }
+
+        contentResolver.openOutputStream(documentUri)?.use { outputStream ->
+            BufferedReader(FileReader(File(filePath))).use { fileReader ->
+                try {
+                    var line: String?
+
+                    while(fileReader.readLine().also { line = it } != null) {
+                        outputStream.write(line?.toByteArray())
+                        outputStream.write(System.lineSeparator().toByteArray())
+                    }
+
+                    result.success(null)
+                } catch (exception: Exception) {
+                    // Delete the orphaned MediaStore record.
+                    contentResolver.delete(documentUri, null, null)
+
+                    result.error(
+                        WRITE_FILE_FAILED_ERROR_CODE,
+                        WRITE_FILE_FAILED_ERROR_MESSAGE,
+                        exception.message
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/be/weforza/app/MediaStoreDelegate.kt
+++ b/android/app/src/main/kotlin/be/weforza/app/MediaStoreDelegate.kt
@@ -116,16 +116,10 @@ class MediaStoreDelegate {
             contentValues.put(MediaStore.Files.FileColumns.DATA, filePath)
         }
 
-        val volumeName = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            MediaStore.VOLUME_EXTERNAL
-        } else {
-            "external"
-        }
-
         var documentUri: Uri? = null
 
         try {
-            documentUri = contentResolver.insert(MediaStore.Files.getContentUri(volumeName), contentValues)
+            documentUri = contentResolver.insert(MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL), contentValues)
         } catch (exception: Exception) {
             // Fallthrough to handle the null document URI.
         }

--- a/android/app/src/main/kotlin/be/weforza/app/PermissionHandler.kt
+++ b/android/app/src/main/kotlin/be/weforza/app/PermissionHandler.kt
@@ -26,6 +26,7 @@ class PermissionHandler {
         const val PERMISSION_REQUEST_ONGOING_MESSAGE = "Another permission request is ongoing."
 
         const val REQUEST_CODE_BLUETOOTH_PERMISSION = 2000
+        const val REQUEST_CODE_WRITE_EXTERNAL_STORAGE_PERMISSION = 2001
     }
 
     // The permission listener that will listen for the permission result.
@@ -128,11 +129,26 @@ class PermissionHandler {
     }
 
     /**
+     * Request permission to write to external storage.
+     *
+     * This permission has no effect on Android 10 and higher.
+     */
+    fun requestWriteExternalStoragePermission(activity: Activity, callback: PermissionResultCallback) {
+        requestPermissions(
+            activity,
+            arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
+            REQUEST_CODE_WRITE_EXTERNAL_STORAGE_PERMISSION,
+            callback,
+        )
+    }
+
+    /**
      * Whether the given request code should be handled by the permission delegate.
      */
     fun shouldHandleRequestCode(requestCode: Int): Boolean {
         return when(requestCode) {
-            REQUEST_CODE_BLUETOOTH_PERMISSION -> true
+            REQUEST_CODE_BLUETOOTH_PERMISSION,
+            REQUEST_CODE_WRITE_EXTERNAL_STORAGE_PERMISSION -> true
             else -> false
         }
     }

--- a/lib/native_service/bluetooth_adapter.dart
+++ b/lib/native_service/bluetooth_adapter.dart
@@ -8,7 +8,7 @@ import 'package:weforza/bluetooth/bluetooth_state.dart';
 import 'package:weforza/native_service/native_service.dart';
 
 /// This class represents a [NativeService] for the Bluetooth adapter on the device.
-class BluetoothAdapter extends NativeService implements BluetoothDeviceScanner {
+final class BluetoothAdapter extends NativeService implements BluetoothDeviceScanner {
   /// The controller that manages the value
   /// that indicates whether a Bluetooth device scan is currently in progress.
   final BehaviorSubject<bool> _isScanningController = BehaviorSubject.seeded(false);

--- a/lib/native_service/file_provider.dart
+++ b/lib/native_service/file_provider.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+
+import 'package:mime/mime.dart';
+import 'package:path/path.dart';
+import 'package:weforza/native_service/native_service.dart';
+
+/// This class represents a service that provides a mechanism
+/// to register new files in the underlying file provider.
+final class FileProvider extends NativeService {
+  const FileProvider();
+
+  /// Whether the application uses Scoped Storage.
+  /// This only has an effect on Android.
+  Future<bool> hasScopedStorage() async {
+    if (Platform.isAndroid) {
+      return await methodChannel.invokeMethod<bool>('hasScopedStorage') ?? false;
+    }
+
+    return false;
+  }
+
+  /// Register the given [file] as a new document.
+  ///
+  /// Throws if the file is empty or an invalid format.
+  Future<void> registerDocument(File file) async {
+    final String? mimeType = lookupMimeType(file.path);
+    final int fileSize = file.lengthSync();
+
+    if (fileSize == 0) {
+      throw ArgumentError.value(fileSize, 'fileSize', 'An empty file cannot be registered as a document.');
+    }
+
+    switch (mimeType) {
+      case 'application/json':
+      case 'text/csv':
+        await methodChannel.invokeMethod<void>(
+          'registerDocument',
+          {
+            'filePath': file.path,
+            'fileName': basename(file.path),
+            'fileSize': fileSize,
+            'fileType': mimeType,
+          },
+        );
+      default:
+        throw ArgumentError.value(
+          mimeType,
+          'mimeType',
+          'The given MIME type, $mimeType is not a supported document type.',
+        );
+    }
+  }
+
+  /// Request permission to write to external storage.
+  ///
+  /// This permission only has an effect on Android 9 and lower, where Scoped Storage is not in effect.
+  Future<bool> requestWriteExternalStoragePermission() async {
+    final bool? result = await methodChannel.invokeMethod<bool>(
+      'requestWriteExternalStoragePermission',
+    );
+
+    return result ?? false;
+  }
+}

--- a/lib/native_service/native_service.dart
+++ b/lib/native_service/native_service.dart
@@ -6,7 +6,9 @@ import 'package:flutter/services.dart';
 /// It exposes a [MethodChannel] for calling the underlying native service.
 ///
 /// It also exposes several [EventChannel]s for events that are emitted by the underlying native service.
-abstract class NativeService {
+base class NativeService {
+  const NativeService();
+
   /// The [MethodChannel] that is used to call methods on the native service.
   final MethodChannel methodChannel = const MethodChannel('be.weforza.app/methods');
 

--- a/lib/widgets/common/generic_error.dart
+++ b/lib/widgets/common/generic_error.dart
@@ -158,3 +158,65 @@ class GenericErrorWithBackButton extends StatelessWidget {
     );
   }
 }
+
+/// This class represents a generic error widget with an [icon] at the top,
+/// an [errorMessage] below the icon, a [primaryButton] and an optional [secondaryButton].
+class GenericErrorWithPrimaryAndSecondaryAction extends StatelessWidget {
+  const GenericErrorWithPrimaryAndSecondaryAction({
+    required this.icon,
+    required this.primaryButton,
+    this.errorMessage,
+    this.secondaryButton,
+    super.key,
+  });
+
+  /// The error message to display.
+  ///
+  /// If this is null, [S.genericError] is used.
+  final String? errorMessage;
+
+  /// The icon that is shown above the [errorMessage].
+  final Widget icon;
+
+  /// The button for the primary action.
+  final Widget primaryButton;
+
+  /// The button for the secondary action.
+  final Widget? secondaryButton;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        IconTheme(
+          data: IconThemeData(
+            size: MediaQuery.sizeOf(context).shortestSide * .1,
+          ),
+          child: icon,
+        ),
+        Flexible(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(8, 8, 8, 20),
+            child: Text(
+              errorMessage ?? S.of(context).genericError,
+              textAlign: TextAlign.center,
+              softWrap: true,
+            ),
+          ),
+        ),
+        OverflowBar(
+          alignment: MainAxisAlignment.center,
+          overflowAlignment: OverflowBarAlignment.center,
+          overflowDirection: VerticalDirection.up,
+          overflowSpacing: 16,
+          spacing: 8,
+          children: [
+            if (secondaryButton != null) secondaryButton!,
+            primaryButton,
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
@@ -4,67 +4,9 @@ import 'package:app_settings/app_settings.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:weforza/generated/l10n.dart';
+import 'package:weforza/widgets/common/generic_error.dart';
 import 'package:weforza/widgets/platform/platform_aware_icon.dart';
 import 'package:weforza/widgets/platform/platform_aware_widget.dart';
-
-class _GenericScanErrorBase extends StatelessWidget {
-  const _GenericScanErrorBase({
-    required this.icon,
-    required this.primaryButton,
-    this.errorMessage,
-    this.secondaryButton,
-  });
-
-  /// The error message to display.
-  ///
-  /// If this is null, [S.genericError] is used.
-  final String? errorMessage;
-
-  /// The icon that is shown above the [errorMessage].
-  final Widget icon;
-
-  /// The button for the primary action.
-  final Widget primaryButton;
-
-  /// The button for the secondary action.
-  final Widget? secondaryButton;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        IconTheme(
-          data: IconThemeData(
-            size: MediaQuery.sizeOf(context).shortestSide * .1,
-          ),
-          child: icon,
-        ),
-        Flexible(
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(8, 8, 8, 20),
-            child: Text(
-              errorMessage ?? S.of(context).genericError,
-              textAlign: TextAlign.center,
-              softWrap: true,
-            ),
-          ),
-        ),
-        OverflowBar(
-          alignment: MainAxisAlignment.center,
-          overflowAlignment: OverflowBarAlignment.center,
-          overflowDirection: VerticalDirection.up,
-          overflowSpacing: 16,
-          spacing: 8,
-          children: [
-            if (secondaryButton != null) secondaryButton!,
-            primaryButton,
-          ],
-        ),
-      ],
-    );
-  }
-}
 
 /// This widget represents a scan error that indicates that Bluetooth is disabled.
 /// It provides a button to open the Bluetooth settings and a button to retry the scan.
@@ -80,7 +22,7 @@ class BluetoothDisabledError extends StatelessWidget {
   Widget build(BuildContext context) {
     final translator = S.of(context);
 
-    return _GenericScanErrorBase(
+    return GenericErrorWithPrimaryAndSecondaryAction(
       errorMessage: translator.scanAbortedBluetoothDisabled,
       icon: const PlatformAwareIcon(
         androidIcon: Icons.bluetooth_disabled,
@@ -118,7 +60,7 @@ class GenericScanError extends StatelessWidget {
   Widget build(BuildContext context) {
     final translator = S.of(context);
 
-    return _GenericScanErrorBase(
+    return GenericErrorWithPrimaryAndSecondaryAction(
       icon: const PlatformAwareIcon(
         androidIcon: Icons.warning,
         iosIcon: CupertinoIcons.exclamationmark_triangle_fill,
@@ -159,7 +101,7 @@ class PermissionDeniedError extends StatelessWidget {
       errorMessage = translator.scanAbortedBluetoothPermissionDenied;
     }
 
-    return _GenericScanErrorBase(
+    return GenericErrorWithPrimaryAndSecondaryAction(
       errorMessage: errorMessage,
       icon: const PlatformAwareIcon(
         androidIcon: Icons.warning,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -366,13 +366,13 @@ packages:
     source: hosted
     version: "1.9.1"
   mime:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: mime
-      sha256: "52e38f7e1143ef39daf532117d6b8f8f617bf4bcd6044ed8c29040d20d269630"
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   node_preamble:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,9 @@ dependencies:
   # Jiffy provides better support for manipulating dates than the current Dart spec.
   jiffy: ^6.1.0
 
+  # This package provies MIME-type lookup utilities.
+  mime: ^1.0.4
+
   # package_info_plus provides access to app specific information such as build number & version.
   package_info_plus: ^4.0.0
 


### PR DESCRIPTION
This PR adds some of the standalone changes for the scoped storage improvements:

- functionality for registering media with the MediaStore
- functionality for requesting the `WRITE_EXTERNAL_STORAGE` permission
- functionality for checking if Android ScopedStorage is enabled
- make the generic scan error base widget public
- adding package mime to dependencies