### PR TITLE
Sort rider exports

### DIFF
--- a/lib/database/export_rides_dao.dart
+++ b/lib/database/export_rides_dao.dart
@@ -130,13 +130,7 @@ class ExportRidesDaoImpl implements ExportRidesDao {
 
   @override
   Future<Iterable<ExportableRide>> getRides(DateTime? ride) async {
-    final attendeesFuture = _getAttendees(ride);
-    final ridersFuture = _getRiders();
-    final ridesFuture = _getRides(ride);
-
-    final attendees = await attendeesFuture;
-    final riders = await ridersFuture;
-    final rides = await ridesFuture;
+    final (attendees, riders, rides) = await (_getAttendees(ride), _getRiders(), _getRides(ride)).wait;
 
     return _joinRidesAndAttendees(attendees, riders, rides);
   }

--- a/lib/database/export_rides_dao.dart
+++ b/lib/database/export_rides_dao.dart
@@ -120,12 +120,16 @@ class ExportRidesDaoImpl implements ExportRidesDao {
         }
       }
 
+      // Sort the attendees per ride, based on name and alias.
+      exportableRideAttendees.sort((a1, a2) => a1.compareTo(a2));
+
       exports.add(
         ExportableRide(ride: ride.value, attendees: exportableRideAttendees),
       );
     }
 
-    return exports;
+    // Sort the exportable rides on their dates, with the most recent date first.
+    return exports..sort((e1, e2) => e1.ride.date.compareTo(e2.ride.date));
   }
 
   @override

--- a/lib/database/import_riders_dao.dart
+++ b/lib/database/import_riders_dao.dart
@@ -70,13 +70,7 @@ class ImportRidersDaoImpl implements ImportRidersDao {
   Future<void> saveSerializableRiders(
     Iterable<SerializableRider> riders,
   ) async {
-    // Since Future.wait() expects the same datatypes from all Futures,
-    // it cannot be used here. Instead, start (but not await) each computation.
-    final existingDevicesFuture = _getExistingDevices();
-    final existingRidersFuture = _getExistingRiders();
-
-    final existingDevices = await existingDevicesFuture;
-    final existingRiders = await existingRidersFuture;
+    final (existingDevices, existingRiders) = await (_getExistingDevices(), _getExistingRiders()).wait;
 
     // The existing riders that should be updated.
     final ridersToUpdate = <SerializableRiderUpdateTimestamp>{};

--- a/lib/model/export/exportable_ride.dart
+++ b/lib/model/export/exportable_ride.dart
@@ -23,7 +23,7 @@ class ExportableRide {
 
 /// This class represents a RideAttendee in a format that is suitable
 /// for exporting inside a [ExportableRide].
-class ExportableRideAttendee {
+class ExportableRideAttendee implements Comparable<ExportableRideAttendee> {
   ExportableRideAttendee({
     required this.firstName,
     required this.lastName,
@@ -43,5 +43,38 @@ class ExportableRideAttendee {
 
   String toCsv() {
     return '$firstName,$lastName${alias.isEmpty ? '' : ',$alias'}';
+  }
+
+  @override
+  int compareTo(ExportableRideAttendee other) {
+    final firstNameComparison = firstName.compareTo(other.firstName);
+
+    if (firstNameComparison != 0) {
+      return firstNameComparison;
+    }
+
+    final lastNameComparison = lastName.compareTo(other.lastName);
+
+    if (lastNameComparison != 0) {
+      return lastNameComparison;
+    }
+
+    // Both aliases are empty, thus both are equal.
+    if (alias.isEmpty && other.alias.isEmpty) {
+      return 0;
+    }
+
+    // This object has more priority based on its alias.
+    if (alias.isNotEmpty && other.alias.isEmpty) {
+      return -1;
+    }
+
+    // This object has less priority based on its alias.
+    if (alias.isEmpty && other.alias.isNotEmpty) {
+      return 1;
+    }
+
+    // Both have non-empty aliases, compare them.
+    return alias.compareTo(other.alias);
   }
 }

--- a/lib/model/rider/serializable_rider.dart
+++ b/lib/model/rider/serializable_rider.dart
@@ -1,7 +1,7 @@
 import 'package:weforza/extensions/date_extension.dart';
 
 /// This class represents a single rider that can be (de)serialized.
-class SerializableRider {
+class SerializableRider implements Comparable<SerializableRider> {
   /// The default constructor.
   SerializableRider({
     required this.active,
@@ -63,6 +63,54 @@ class SerializableRider {
       'lastName': lastName,
       'lastUpdated': lastUpdated.toStringWithoutMilliseconds(),
     };
+  }
+
+  @override
+  int compareTo(SerializableRider other) {
+    final firstNameComparison = firstName.compareTo(other.firstName);
+
+    if (firstNameComparison != 0) {
+      return firstNameComparison;
+    }
+
+    final lastNameComparison = lastName.compareTo(other.lastName);
+
+    if (lastNameComparison != 0) {
+      return lastNameComparison;
+    }
+
+    // Both aliases are empty, thus both are equal.
+    if (alias.isEmpty && other.alias.isEmpty) {
+      return 0;
+    }
+
+    // This object has more priority based on its alias.
+    if (alias.isNotEmpty && other.alias.isEmpty) {
+      return -1;
+    }
+
+    // This object has less priority based on its alias.
+    if (alias.isEmpty && other.alias.isNotEmpty) {
+      return 1;
+    }
+
+    // Both have non-empty aliases, compare them.
+    final aliasComparison = alias.compareTo(other.alias);
+
+    if (aliasComparison != 0) {
+      return aliasComparison;
+    }
+
+    // As a last resort, compare the active states.
+    if (active && !other.active) {
+      return -1;
+    }
+
+    if (!active && other.active) {
+      return 1;
+    }
+
+    return 0;
   }
 }
 

--- a/lib/repository/serialize_riders_repository.dart
+++ b/lib/repository/serialize_riders_repository.dart
@@ -22,13 +22,10 @@ class SerializeRidersRepository {
   ///
   /// The returned list is sorted on the rider name, alias and active state.
   Future<Iterable<SerializableRider>> getSerializableRiders() async {
-    // Since Future.wait() expects the same datatypes from all Futures,
-    // it cannot be used here. Instead, start (but not await) each computation.
-    final devicesFuture = deviceDao.getAllDevicesGroupedByOwnerId();
-    final ridersFuture = riderDao.getRiders(RiderFilterOption.all);
-
-    final devices = await devicesFuture;
-    final riders = await ridersFuture;
+    final (devices, riders) = await (
+      deviceDao.getAllDevicesGroupedByOwnerId(),
+      riderDao.getRiders(RiderFilterOption.all),
+    ).wait;
 
     final output = riders
         .map(

--- a/lib/repository/serialize_riders_repository.dart
+++ b/lib/repository/serialize_riders_repository.dart
@@ -19,6 +19,8 @@ class SerializeRidersRepository {
   final RiderDao riderDao;
 
   /// Get the collection of serializable riders.
+  ///
+  /// The returned list is sorted on the rider name, alias and active state.
   Future<Iterable<SerializableRider>> getSerializableRiders() async {
     // Since Future.wait() expects the same datatypes from all Futures,
     // it cannot be used here. Instead, start (but not await) each computation.
@@ -28,16 +30,22 @@ class SerializeRidersRepository {
     final devices = await devicesFuture;
     final riders = await ridersFuture;
 
-    return riders.map(
-      (rider) => SerializableRider(
-        active: rider.active,
-        alias: rider.alias,
-        devices: devices[rider.uuid] ?? <String>{},
-        firstName: rider.firstName,
-        lastName: rider.lastName,
-        lastUpdated: rider.lastUpdated,
-      ),
-    );
+    final output = riders
+        .map(
+          (rider) => SerializableRider(
+            active: rider.active,
+            alias: rider.alias,
+            devices: devices[rider.uuid] ?? <String>{},
+            firstName: rider.firstName,
+            lastName: rider.lastName,
+            lastUpdated: rider.lastUpdated,
+          ),
+        )
+        .toList();
+
+    output.sort((s1, s2) => s1.compareTo(s2));
+
+    return output;
   }
 
   /// Save the given serializable [riders] to disk.


### PR DESCRIPTION
This PR adds sorting for the riders export (first name, last name, alias, active; in the specified order) and the rides export (rides on date, most recent date first; attendees on first name, last name, alias; per ride)

It also uses the new record await feature for some minor cleanup

Fixes #393