### PR TITLE
File system cleanups - Part 1

### DIFF
--- a/lib/file/file_system.dart
+++ b/lib/file/file_system.dart
@@ -33,13 +33,6 @@ abstract interface class FileSystem {
   /// rather than top-level shared storage.
   fs.Directory? imagesDirectory({required bool applicationDirectory});
 
-  /// Choose the file to use as data source
-  /// for importing riders and their devices.
-  ///
-  /// Returns the chosen file or null if no file was chosen.
-  /// Throws an [UnsupportedFileFormatException] if a file with an unsupported file type was chosen.
-  Future<fs.File?> pickImportRidersDataSource();
-
   /// Pick a profile image from the given [source].
   /// Returns the [fs.File] that was chosen.
   Future<fs.File?> pickProfileImage(ImageSource source);

--- a/lib/file/file_system.dart
+++ b/lib/file/file_system.dart
@@ -1,5 +1,4 @@
 import 'package:file/file.dart' as fs;
-import 'package:image_picker/image_picker.dart';
 
 /// This interface defines the application's file system.
 abstract interface class FileSystem {
@@ -32,8 +31,4 @@ abstract interface class FileSystem {
   /// If [applicationDirectory] is true, the returned directory will be specific to the application,
   /// rather than top-level shared storage.
   fs.Directory? imagesDirectory({required bool applicationDirectory});
-
-  /// Pick a profile image from the given [source].
-  /// Returns the [fs.File] that was chosen.
-  Future<fs.File?> pickProfileImage(ImageSource source);
 }

--- a/lib/file/io_file_system.dart
+++ b/lib/file/io_file_system.dart
@@ -1,8 +1,6 @@
 import 'dart:io' show Platform;
 
 import 'package:file/file.dart' as fs;
-import 'package:image_picker/image_picker.dart';
-import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:weforza/file/file_system.dart';
 
@@ -143,47 +141,5 @@ class IoFileSystem implements FileSystem {
     }
 
     return null;
-  }
-
-  @override
-  Future<fs.File?> pickProfileImage(ImageSource source) async {
-    // TODO: refactor this flow
-    // - if scoped storage on Android, register the photo (the registration should return a readable path)
-    // - if not scoped storage on Android
-    //   - request write external storage permission first
-    //   - then save the image to the top-level pictures dir
-    //   - then register the photo
-    // - on iOS
-    //   - request permission for the photo gallery (add only)
-    //   - save the image to the application documents dir
-    //   - register the photo
-
-    final profileImage = await ImagePicker().pickImage(
-      maxHeight: 320,
-      maxWidth: 320,
-      requestFullMetadata: false,
-      source: source,
-    );
-
-    if (profileImage == null) {
-      return null;
-    }
-
-    switch (source) {
-      case ImageSource.camera:
-        final fs.Directory? directory = imagesDirectory(applicationDirectory: false);
-
-        if (directory == null) {
-          throw ArgumentError.notNull('directory');
-        }
-
-        final fs.File destinationFile = file(join(directory.path, profileImage.name));
-
-        await profileImage.saveTo(destinationFile.path);
-
-        return destinationFile;
-      case ImageSource.gallery:
-        return file(profileImage.path);
-    }
   }
 }

--- a/lib/file/io_file_system.dart
+++ b/lib/file/io_file_system.dart
@@ -1,11 +1,9 @@
 import 'dart:io' show Platform;
 
 import 'package:file/file.dart' as fs;
-import 'package:file_picker/file_picker.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:weforza/exceptions/exceptions.dart';
 import 'package:weforza/file/file_system.dart';
 
 /// This class represents a [FileSystem] that uses the real file system.
@@ -145,33 +143,6 @@ class IoFileSystem implements FileSystem {
     }
 
     return null;
-  }
-
-  @override
-  Future<fs.File?> pickImportRidersDataSource() async {
-    final result = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: <String>['csv', 'json'],
-    );
-
-    if (result == null || result.files.isEmpty) {
-      return null;
-    }
-
-    final chosenFile = result.files.first;
-    final ext = chosenFile.extension;
-
-    if (ext == null || (!ext.endsWith('csv') && !ext.endsWith('json'))) {
-      throw UnsupportedFileFormatException();
-    }
-
-    final filePath = chosenFile.path;
-
-    if (filePath == null) {
-      throw UnsupportedFileFormatException();
-    }
-
-    return file(filePath);
   }
 
   @override

--- a/lib/model/image/io_pick_image_delegate.dart
+++ b/lib/model/image/io_pick_image_delegate.dart
@@ -1,0 +1,54 @@
+import 'package:file/file.dart' as fs;
+import 'package:image_picker/image_picker.dart';
+import 'package:path/path.dart';
+import 'package:weforza/file/file_system.dart';
+import 'package:weforza/model/image/pick_image_delegate.dart';
+
+/// The [FileSystem] based implementation of [PickImageDelegate].
+class IoPickImageDelegate implements PickImageDelegate {
+  IoPickImageDelegate({required this.fileSystem});
+
+  final FileSystem fileSystem;
+
+  @override
+  Future<fs.File?> pickProfileImage(ImageSource source) async {
+    // TODO: refactor this flow
+    // - if scoped storage on Android, register the photo (the registration should return a readable path)
+    // - if not scoped storage on Android
+    //   - request write external storage permission first
+    //   - then save the image to the top-level pictures dir
+    //   - then register the photo
+    // - on iOS
+    //   - request permission for the photo gallery (add only)
+    //   - save the image to the application documents dir
+    //   - register the photo
+
+    final profileImage = await ImagePicker().pickImage(
+      maxHeight: 320,
+      maxWidth: 320,
+      requestFullMetadata: false,
+      source: source,
+    );
+
+    if (profileImage == null) {
+      return null;
+    }
+
+    switch (source) {
+      case ImageSource.camera:
+        final fs.Directory? directory = fileSystem.imagesDirectory(applicationDirectory: false);
+
+        if (directory == null) {
+          throw ArgumentError.notNull('directory');
+        }
+
+        final fs.File destinationFile = fileSystem.file(join(directory.path, profileImage.name));
+
+        await profileImage.saveTo(destinationFile.path);
+
+        return destinationFile;
+      case ImageSource.gallery:
+        return fileSystem.file(profileImage.path);
+    }
+  }
+}

--- a/lib/model/image/pick_image_delegate.dart
+++ b/lib/model/image/pick_image_delegate.dart
@@ -1,0 +1,17 @@
+import 'package:file/file.dart';
+import 'package:image_picker/image_picker.dart';
+
+/// This interface defines a delegate for picking a file that is used as a profile image.
+abstract interface class PickImageDelegate {
+  /// Pick a profile image from the given [source].
+  /// If the [source] is [ImageSource.gallery], the original file is returned.
+  ///
+  /// If the [source] is [ImageSource.camera], a new picture is taken using the device camera.
+  /// Before taking a new picture,
+  /// the necessary permissions for accessing the camera and writing to disk are requested.
+  ///
+  /// Returns the [File] that was chosen.
+  /// Returns a [Future.error] if the permissions have been denied.
+  /// Returns a [Future.error] if the device does not have a camera.
+  Future<File?> pickProfileImage(ImageSource source);
+}

--- a/lib/model/image/profile_image_picker_delegate.dart
+++ b/lib/model/image/profile_image_picker_delegate.dart
@@ -3,17 +3,17 @@ import 'dart:io';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:rxdart/rxdart.dart';
-import 'package:weforza/file/file_system.dart';
+import 'package:weforza/model/image/pick_image_delegate.dart';
 
 /// This delegate provides an interface for selecting profile images.
 class ProfileImagePickerDelegate {
   ProfileImagePickerDelegate({
-    required this.fileSystem,
+    required this.imagePickerDelegate,
     required File? initialValue,
   }) : _controller = BehaviorSubject.seeded(AsyncValue.data(initialValue));
 
-  /// The file system for this delegate.
-  final FileSystem fileSystem;
+  /// The delegate that will handle picking images.
+  final PickImageDelegate imagePickerDelegate;
 
   /// The controller that manages the selected file.
   final BehaviorSubject<AsyncValue<File?>> _controller;
@@ -44,7 +44,7 @@ class ProfileImagePickerDelegate {
 
       _controller.add(const AsyncLoading());
 
-      final file = await fileSystem.pickProfileImage(source);
+      final file = await imagePickerDelegate.pickProfileImage(source);
 
       if (_controller.isClosed) {
         return;

--- a/lib/model/import/import_file_delegate.dart
+++ b/lib/model/import/import_file_delegate.dart
@@ -1,0 +1,13 @@
+import 'package:file/file.dart' as fs;
+
+import 'package:weforza/exceptions/exceptions.dart';
+
+/// This interface defines a delegate for picking a file to import data from.
+abstract interface class ImportFileDelegate {
+  /// Choose the file to use as data source
+  /// for importing riders and their devices.
+  ///
+  /// Returns the chosen file or null if no file was chosen.
+  /// Throws an [UnsupportedFileFormatException] if a file with an unsupported file type was chosen.
+  Future<fs.File?> pickImportRidersDataSource();
+}

--- a/lib/model/import/import_riders_delegate.dart
+++ b/lib/model/import/import_riders_delegate.dart
@@ -2,22 +2,22 @@ import 'dart:io';
 
 import 'package:rxdart/rxdart.dart';
 import 'package:weforza/exceptions/exceptions.dart';
-import 'package:weforza/file/file_system.dart';
 import 'package:weforza/file/import_riders_csv_reader.dart';
 import 'package:weforza/file/import_riders_file_reader.dart';
 import 'package:weforza/file/import_riders_json_reader.dart';
 import 'package:weforza/model/export/export_file_format.dart';
+import 'package:weforza/model/import/import_file_delegate.dart';
 import 'package:weforza/model/import/import_riders_state.dart';
 import 'package:weforza/model/rider/serializable_rider.dart';
 import 'package:weforza/repository/serialize_riders_repository.dart';
 
 /// This class represents the delegate that handles importing riders.
 class ImportRidersDelegate {
-  ImportRidersDelegate(this.fileSystem, this.repository);
+  ImportRidersDelegate(this.importFileDelegate, this.repository);
 
   final _controller = BehaviorSubject.seeded(ImportRidersState.idle);
 
-  final FileSystem fileSystem;
+  final ImportFileDelegate importFileDelegate;
 
   final SerializeRidersRepository repository;
 
@@ -82,7 +82,7 @@ class ImportRidersDelegate {
     try {
       _controller.add(ImportRidersState.pickingFile);
 
-      final file = await fileSystem.pickImportRidersDataSource();
+      final file = await importFileDelegate.pickImportRidersDataSource();
 
       if (_controller.isClosed) {
         return;

--- a/lib/model/import/io_import_file_delegate.dart
+++ b/lib/model/import/io_import_file_delegate.dart
@@ -1,0 +1,38 @@
+import 'package:file/file.dart' as fs;
+import 'package:file_picker/file_picker.dart';
+import 'package:weforza/exceptions/exceptions.dart';
+import 'package:weforza/file/file_system.dart';
+import 'package:weforza/model/import/import_file_delegate.dart';
+
+class IoImportFileDelegate implements ImportFileDelegate {
+  IoImportFileDelegate(this.fileSystem);
+
+  final FileSystem fileSystem;
+
+  @override
+  Future<fs.File?> pickImportRidersDataSource() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: <String>['csv', 'json'],
+    );
+
+    if (result == null || result.files.isEmpty) {
+      return null;
+    }
+
+    final chosenFile = result.files.first;
+    final ext = chosenFile.extension;
+
+    if (ext == null || (!ext.endsWith('csv') && !ext.endsWith('json'))) {
+      throw UnsupportedFileFormatException();
+    }
+
+    final filePath = chosenFile.path;
+
+    if (filePath == null) {
+      throw UnsupportedFileFormatException();
+    }
+
+    return fileSystem.file(filePath);
+  }
+}

--- a/lib/riverpod/image_picker_delegate_provider.dart
+++ b/lib/riverpod/image_picker_delegate_provider.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:weforza/model/image/io_pick_image_delegate.dart';
+import 'package:weforza/model/image/pick_image_delegate.dart';
+import 'package:weforza/riverpod/file_system_provider.dart';
+
+final imagePickerDelegateProvider = Provider<PickImageDelegate>((ref) {
+  return IoPickImageDelegate(fileSystem: ref.read(fileSystemProvider));
+});

--- a/lib/riverpod/import_file_delegate_provider.dart
+++ b/lib/riverpod/import_file_delegate_provider.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:weforza/model/import/import_file_delegate.dart';
+import 'package:weforza/model/import/io_import_file_delegate.dart';
+import 'package:weforza/riverpod/file_system_provider.dart';
+
+final importFileDelegateProvider = Provider<ImportFileDelegate>((ref) {
+  return IoImportFileDelegate(ref.read(fileSystemProvider));
+});

--- a/lib/widgets/custom/profile_image/profile_image_picker.dart
+++ b/lib/widgets/custom/profile_image/profile_image_picker.dart
@@ -4,7 +4,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/generated/l10n.dart';
-import 'package:weforza/model/profile_image_picker_delegate.dart';
+import 'package:weforza/model/image/profile_image_picker_delegate.dart';
 import 'package:weforza/widgets/custom/profile_image/profile_image.dart';
 import 'package:weforza/widgets/custom/profile_image/profile_image_picker_placeholder.dart';
 import 'package:weforza/widgets/dialogs/dialogs.dart';

--- a/lib/widgets/pages/import_riders_page.dart
+++ b/lib/widgets/pages/import_riders_page.dart
@@ -5,7 +5,7 @@ import 'package:weforza/exceptions/exceptions.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/model/import/import_riders_delegate.dart';
 import 'package:weforza/model/import/import_riders_state.dart';
-import 'package:weforza/riverpod/file_system_provider.dart';
+import 'package:weforza/riverpod/import_file_delegate_provider.dart';
 import 'package:weforza/riverpod/repository/serialize_riders_repository_provider.dart';
 import 'package:weforza/riverpod/rider/rider_list_provider.dart';
 import 'package:weforza/widgets/common/generic_error.dart';
@@ -40,7 +40,7 @@ class _ImportRidersPageState extends ConsumerState<ImportRidersPage> with Single
   void initState() {
     super.initState();
     delegate = ImportRidersDelegate(
-      ref.read(fileSystemProvider),
+      ref.read(importFileDelegateProvider),
       ref.read(serializeRidersRepositoryProvider),
     );
 

--- a/lib/widgets/pages/rider_form.dart
+++ b/lib/widgets/pages/rider_form.dart
@@ -5,12 +5,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/exceptions/exceptions.dart';
 import 'package:weforza/generated/l10n.dart';
-import 'package:weforza/model/profile_image_picker_delegate.dart';
+import 'package:weforza/model/image/profile_image_picker_delegate.dart';
 import 'package:weforza/model/rider/rider.dart';
 import 'package:weforza/model/rider/rider_form_delegate.dart';
 import 'package:weforza/model/rider/rider_model.dart';
 import 'package:weforza/model/rider/rider_validator.dart';
-import 'package:weforza/riverpod/file_system_provider.dart';
+import 'package:weforza/riverpod/image_picker_delegate_provider.dart';
 import 'package:weforza/riverpod/repository/rider_repository_provider.dart';
 import 'package:weforza/riverpod/rider/rider_list_provider.dart';
 import 'package:weforza/riverpod/rider/selected_rider_provider.dart';
@@ -117,7 +117,7 @@ class _RiderFormState extends ConsumerState<RiderForm> with RiderValidator {
     final profileImageFile = profileImagePath == null ? null : File(profileImagePath);
 
     _profileImageDelegate = ProfileImagePickerDelegate(
-      fileSystem: ref.read(fileSystemProvider),
+      imagePickerDelegate: ref.read(imagePickerDelegateProvider),
       initialValue: profileImageFile?.existsSync() ?? false ? profileImageFile : null,
     );
 


### PR DESCRIPTION
This PR addresses some bits that were left over from the file system refactor:

- the pick profile image was moved out of the file system, into its own delegate
- the pick import datasource was moved out of the file system, into its own delegate