### PR TITLE
File system cleanups - Part 2

### DIFF
--- a/lib/file/file_system.dart
+++ b/lib/file/file_system.dart
@@ -2,33 +2,37 @@ import 'package:file/file.dart' as fs;
 
 /// This interface defines the application's file system.
 abstract interface class FileSystem {
+  /// Get the directory where the application can store documents.
+  ///
+  /// Files in this directory are removed when the application is uninstalled.
+  fs.Directory get documentsDirectory;
+
   /// Whether the file system uses scoped storage.
   ///
   /// If this is true, not all provided directories might be available to the application.
   bool get hasScopedStorage;
 
+  /// Get the directory where the application can store images.
+  ///
+  /// Files in this directory are removed when the application is uninstalled.
+  fs.Directory get imagesDirectory;
+
   /// Get the directory where the application can create temporary files.
   /// This directory is always available.
   fs.Directory get tempDirectory;
 
-  /// Get the directory where the application can store document files.
+  /// Get the directory where the application can store documents,
+  /// that are not removed when the application is uninstalled.
   ///
-  /// If this directory is not available, for instance if it is limited by [hasScopedStorage],
-  /// then this is null.
+  /// Returns null if no such directory is available.
+  fs.Directory? get topLevelDocumentsDirectory;
+
+  /// Get the directory where the application can store images,
+  /// that are not removed when the application is uninstalled.
   ///
-  /// If [applicationDirectory] is true, the returned directory will be specific to the application,
-  /// rather than top-level shared storage.
-  fs.Directory? documentsDirectory({required bool applicationDirectory});
+  /// Returns null if no such directory is available.
+  fs.Directory? get topLevelImagesDirectory;
 
   /// Get a reference to a [fs.File] at the given [path].
   fs.File file(String path);
-
-  /// Get the directory where the application can store images.
-  ///
-  /// If this directory is not available, for instance if it is limited by [hasScopedStorage],
-  /// then this is null.
-  ///
-  /// If [applicationDirectory] is true, the returned directory will be specific to the application,
-  /// rather than top-level shared storage.
-  fs.Directory? imagesDirectory({required bool applicationDirectory});
 }

--- a/lib/file/io_file_system.dart
+++ b/lib/file/io_file_system.dart
@@ -1,37 +1,32 @@
-import 'dart:io' show Platform;
-
 import 'package:file/file.dart' as fs;
-import 'package:path_provider/path_provider.dart';
 import 'package:weforza/file/file_system.dart';
 
 /// This class represents a [FileSystem] that uses the real file system.
 class IoFileSystem implements FileSystem {
   /// Create a new [IoFileSystem] with the given directories.
   IoFileSystem({
-    required fs.Directory applicationDocumentsDirectory,
-    required fs.Directory applicationImagesDirectory,
+    required this.documentsDirectory,
+    required this.imagesDirectory,
     required fs.FileSystem fileSystem,
     required this.hasScopedStorage,
     required this.tempDirectory,
-    fs.Directory? documentsDirectory,
-    fs.Directory? imagesDirectory,
-  })  : _applicationDocumentsDirectory = applicationDocumentsDirectory,
-        _applicationImagesDirectory = applicationImagesDirectory,
-        _documentsDirectory = documentsDirectory,
-        _fileSystem = fileSystem,
-        _imagesDirectory = imagesDirectory;
+    fs.Directory? topLevelDocumentsDirectory,
+    fs.Directory? topLevelImagesDirectory,
+  })  : topLevelDocumentsDirectory = hasScopedStorage ? null : topLevelDocumentsDirectory,
+        topLevelImagesDirectory = hasScopedStorage ? null : topLevelImagesDirectory,
+        _fileSystem = fileSystem;
 
-  /// The directory for application private files.
-  final fs.Directory _applicationDocumentsDirectory;
+  @override
+  final fs.Directory documentsDirectory;
 
-  /// The directory for application private images.
-  final fs.Directory _applicationImagesDirectory;
+  @override
+  final fs.Directory imagesDirectory;
 
-  /// The directory for documents that are not private to the application.
-  final fs.Directory? _documentsDirectory;
+  @override
+  final fs.Directory? topLevelDocumentsDirectory;
 
-  /// The directory for images that are not private to the application.
-  final fs.Directory? _imagesDirectory;
+  @override
+  final fs.Directory? topLevelImagesDirectory;
 
   /// The underlying file system.
   final fs.FileSystem _fileSystem;
@@ -42,104 +37,6 @@ class IoFileSystem implements FileSystem {
   @override
   final fs.Directory tempDirectory;
 
-  /// Create a new [IoFileSystem] from the directories provided by the current platform.
-  static Future<IoFileSystem> fromPlatform({
-    required fs.FileSystem fileSystem,
-    required bool hasAndroidScopedStorage,
-  }) async {
-    final tempDirectory = await getTemporaryDirectory();
-    final fs.Directory applicationDocumentsDirectory = await getApplicationDocumentsDirectory().then(
-      (dir) => fileSystem.directory(dir.path),
-    );
-
-    if (Platform.isAndroid) {
-      // Don't fetch the external storage directories when they are not available.
-      if (hasAndroidScopedStorage) {
-        return IoFileSystem(
-          applicationDocumentsDirectory: applicationDocumentsDirectory,
-          applicationImagesDirectory: applicationDocumentsDirectory,
-          fileSystem: fileSystem,
-          hasScopedStorage: true,
-          tempDirectory: fileSystem.directory(tempDirectory.path),
-        );
-      }
-
-      final documentsDirs = await getExternalStorageDirectories(type: StorageDirectory.documents) ?? [];
-      final imagesDirs = await getExternalStorageDirectories(type: StorageDirectory.pictures) ?? [];
-
-      return IoFileSystem(
-        applicationDocumentsDirectory: applicationDocumentsDirectory,
-        applicationImagesDirectory: applicationDocumentsDirectory,
-        documentsDirectory: documentsDirs.isEmpty ? null : fileSystem.directory(documentsDirs.first.path),
-        imagesDirectory: imagesDirs.isEmpty ? null : fileSystem.directory(imagesDirs.first.path),
-        fileSystem: fileSystem,
-        hasScopedStorage: hasAndroidScopedStorage,
-        tempDirectory: fileSystem.directory(tempDirectory.path),
-      );
-    }
-
-    if (Platform.isIOS) {
-      return IoFileSystem(
-        applicationDocumentsDirectory: applicationDocumentsDirectory,
-        applicationImagesDirectory: applicationDocumentsDirectory,
-        fileSystem: fileSystem,
-        hasScopedStorage: false,
-        tempDirectory: fileSystem.directory(tempDirectory.path),
-      );
-    }
-
-    throw UnsupportedError('Only Android and iOS are currently supported.');
-  }
-
-  @override
-  fs.Directory? documentsDirectory({required bool applicationDirectory}) {
-    if (Platform.isAndroid) {
-      // The documents directory is protected with scoped storage.
-      if (hasScopedStorage) {
-        return null;
-      }
-
-      if (applicationDirectory) {
-        return _fileSystem.directory(_applicationDocumentsDirectory);
-      }
-
-      final fs.Directory? dir = _documentsDirectory;
-
-      return dir == null ? null : _fileSystem.directory(dir.path);
-    }
-
-    if (Platform.isIOS) {
-      return _fileSystem.directory(_applicationDocumentsDirectory);
-    }
-
-    return null;
-  }
-
   @override
   fs.File file(String path) => _fileSystem.file(path);
-
-  @override
-  fs.Directory? imagesDirectory({required bool applicationDirectory}) {
-    if (Platform.isAndroid) {
-      // The pictures directory is protected with scoped storage.
-      if (hasScopedStorage) {
-        return null;
-      }
-
-      if (applicationDirectory) {
-        return _fileSystem.directory(_applicationImagesDirectory);
-      }
-
-      final fs.Directory? dir = _imagesDirectory;
-
-      return dir == null ? null : _fileSystem.directory(dir.path);
-    }
-
-    // iOS does not have a pictures directory.
-    if (Platform.isIOS) {
-      return _fileSystem.directory(_applicationDocumentsDirectory);
-    }
-
-    return null;
-  }
 }

--- a/lib/file/io_file_system.dart
+++ b/lib/file/io_file_system.dart
@@ -1,3 +1,4 @@
+import 'dart:io' as io show Directory;
 import 'package:file/file.dart' as fs;
 import 'package:weforza/file/file_system.dart';
 
@@ -5,15 +6,21 @@ import 'package:weforza/file/file_system.dart';
 class IoFileSystem implements FileSystem {
   /// Create a new [IoFileSystem] with the given directories.
   IoFileSystem({
-    required this.documentsDirectory,
-    required this.imagesDirectory,
+    required io.Directory documentsDirectory,
+    required io.Directory imagesDirectory,
     required fs.FileSystem fileSystem,
     required this.hasScopedStorage,
-    required this.tempDirectory,
-    fs.Directory? topLevelDocumentsDirectory,
-    fs.Directory? topLevelImagesDirectory,
-  })  : topLevelDocumentsDirectory = hasScopedStorage ? null : topLevelDocumentsDirectory,
-        topLevelImagesDirectory = hasScopedStorage ? null : topLevelImagesDirectory,
+    required io.Directory tempDirectory,
+    io.Directory? topLevelDocumentsDirectory,
+    io.Directory? topLevelImagesDirectory,
+  })  : documentsDirectory = fileSystem.directory(documentsDirectory),
+        imagesDirectory = fileSystem.directory(imagesDirectory),
+        tempDirectory = fileSystem.directory(tempDirectory),
+        topLevelDocumentsDirectory = hasScopedStorage || topLevelDocumentsDirectory == null
+            ? null
+            : fileSystem.directory(topLevelDocumentsDirectory),
+        topLevelImagesDirectory =
+            hasScopedStorage || topLevelImagesDirectory == null ? null : fileSystem.directory(topLevelImagesDirectory),
         _fileSystem = fileSystem;
 
   @override

--- a/lib/model/export/export_delegate.dart
+++ b/lib/model/export/export_delegate.dart
@@ -81,11 +81,7 @@ abstract class ExportDelegate<Options> extends AsyncComputationDelegate<void> {
       // On iOS, the exported files are saved to the application documents directory.
       // Check if the file does not exist yet, and write to the file.
       if (Platform.isIOS) {
-        final fs.Directory? directory = fileSystem.documentsDirectory(applicationDirectory: true);
-
-        if (directory == null) {
-          throw ArgumentError.notNull('directory');
-        }
+        final fs.Directory directory = fileSystem.documentsDirectory;
 
         final fs.File file = fileSystem.file(join(directory.path, fileName));
 
@@ -110,7 +106,7 @@ abstract class ExportDelegate<Options> extends AsyncComputationDelegate<void> {
         } else {
           // When not using ScopedStorage, write to the external public documents directory,
           // but request permission first. Lastly, register the file using the file provider.
-          final fs.Directory? directory = fileSystem.documentsDirectory(applicationDirectory: false);
+          final fs.Directory? directory = fileSystem.topLevelDocumentsDirectory;
 
           if (directory == null) {
             throw ArgumentError.notNull('directory');

--- a/lib/model/image/io_pick_image_delegate.dart
+++ b/lib/model/image/io_pick_image_delegate.dart
@@ -36,7 +36,7 @@ class IoPickImageDelegate implements PickImageDelegate {
 
     switch (source) {
       case ImageSource.camera:
-        final fs.Directory? directory = fileSystem.imagesDirectory(applicationDirectory: false);
+        final fs.Directory? directory = fileSystem.topLevelImagesDirectory;
 
         if (directory == null) {
           throw ArgumentError.notNull('directory');

--- a/lib/widgets/pages/export_data_page/export_data_file_name_text_field.dart
+++ b/lib/widgets/pages/export_data_page/export_data_file_name_text_field.dart
@@ -58,7 +58,7 @@ class ExportDataFileNameTextField<T> extends StatelessWidget {
       }
 
       // When ScopedStorage is not enabled, the document is written to the external public documents directory.
-      final Directory? directory = delegate.fileSystem.documentsDirectory(applicationDirectory: false);
+      final Directory? directory = delegate.fileSystem.topLevelDocumentsDirectory;
 
       if (directory == null) {
         return null;
@@ -71,11 +71,7 @@ class ExportDataFileNameTextField<T> extends StatelessWidget {
 
     // On iOS, the exported files are saved to the application documents directory.
     if (Platform.isIOS) {
-      final Directory? directory = delegate.fileSystem.documentsDirectory(applicationDirectory: true);
-
-      if (directory == null) {
-        return null;
-      }
+      final Directory directory = delegate.fileSystem.documentsDirectory;
 
       if (delegate.fileSystem.file(join(directory.path, fileName)).existsSync()) {
         return translator.fileNameExists;


### PR DESCRIPTION
This PR cleans up the `FileSystem` so that initialisation is sync and the API for documents dirs uses specific getters, without booleans.