### PR TITLE
Rename `FileProvider`

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,6 +29,8 @@ void main() async {
   // Preload the package info.
   final packageInfo = await PackageInfo.fromPlatform();
 
+  // The delegate that looks up whether the storage is scoped is a constant.
+  // Therefor the delegate here and in the respective provider, evaluates to the same object.
   final bool hasAndroidScopedStorage = await const IoFileStorageDelegate().hasScopedStorage();
 
   final Directory applicationDocumentsDirectory = await getApplicationDocumentsDirectory();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:weforza/database/database.dart';
 import 'package:weforza/database/sembast_database.dart';
 import 'package:weforza/file/file_system.dart';
 import 'package:weforza/file/io_file_system.dart';
-import 'package:weforza/native_service/file_provider.dart';
+import 'package:weforza/native_service/io_file_storage_delegate.dart';
 import 'package:weforza/riverpod/database/database_provider.dart';
 import 'package:weforza/riverpod/file_system_provider.dart';
 import 'package:weforza/riverpod/package_info_provider.dart';
@@ -29,7 +29,7 @@ void main() async {
   // Preload the package info.
   final packageInfo = await PackageInfo.fromPlatform();
 
-  final bool hasAndroidScopedStorage = await const FileProvider().hasScopedStorage();
+  final bool hasAndroidScopedStorage = await const IoFileStorageDelegate().hasScopedStorage();
 
   final Directory applicationDocumentsDirectory = await getApplicationDocumentsDirectory();
   final Directory tempDirectory = await getTemporaryDirectory();

--- a/lib/model/export/export_delegate.dart
+++ b/lib/model/export/export_delegate.dart
@@ -8,20 +8,20 @@ import 'package:weforza/exceptions/exceptions.dart';
 import 'package:weforza/file/file_system.dart';
 import 'package:weforza/model/async_computation_delegate.dart';
 import 'package:weforza/model/export/export_file_format.dart';
-import 'package:weforza/native_service/file_provider.dart';
+import 'package:weforza/native_service/file_storage_delegate.dart';
 
 /// This class represents a delegate that handles exporting data.
 abstract class ExportDelegate<Options> extends AsyncComputationDelegate<void> {
   /// The default constructor.
-  ExportDelegate({required this.fileSystem});
+  ExportDelegate({required this.fileStorageDelegate, required this.fileSystem});
 
   /// The controller that keeps track of the selected file format.
   ///
   /// By default, [ExportFileFormat.csv] is used as the initial value.
   final _fileFormatController = BehaviorSubject.seeded(ExportFileFormat.csv);
 
-  /// The file provider that will register the document.
-  final FileProvider fileProvider = const FileProvider();
+  /// The file storage delegate that will register the document.
+  final FileStorageDelegate fileStorageDelegate;
 
   /// The file system that will provide directories.
   final FileSystem fileSystem;
@@ -118,14 +118,14 @@ abstract class ExportDelegate<Options> extends AsyncComputationDelegate<void> {
             throw StateError('The given file $file already exists');
           }
 
-          if (!await fileProvider.requestWriteExternalStoragePermission()) {
+          if (!await fileStorageDelegate.requestWriteExternalStoragePermission()) {
             throw ExternalStoragePermissionDeniedException();
           }
         }
 
         await writeToFile(file, fileFormat, options);
 
-        await fileProvider.registerDocument(file);
+        await fileStorageDelegate.registerDocument(file);
 
         setDone(null);
         return;

--- a/lib/model/export/export_riders_delegate.dart
+++ b/lib/model/export/export_riders_delegate.dart
@@ -17,6 +17,7 @@ class ExportRidersOptions {
 /// This class represents the delegate that handles exporting riders.
 class ExportRidersDelegate extends ExportDelegate<ExportRidersOptions> {
   ExportRidersDelegate({
+    required super.fileStorageDelegate,
     required super.fileSystem,
     required this.serializeRidersRepository,
   });

--- a/lib/model/export/export_rides_delegate.dart
+++ b/lib/model/export/export_rides_delegate.dart
@@ -18,6 +18,7 @@ class ExportRidesOptions {
 /// This class represents the delegate that handles exporting rides.
 class ExportRidesDelegate extends ExportDelegate<ExportRidesOptions> {
   ExportRidesDelegate({
+    required super.fileStorageDelegate,
     required super.fileSystem,
     required this.repository,
   });

--- a/lib/native_service/file_storage_delegate.dart
+++ b/lib/native_service/file_storage_delegate.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+
+import 'package:weforza/native_service/native_service.dart';
+
+/// This class defines an interface that allows working with the underlying file provider.
+abstract base class FileStorageDelegate extends NativeService {
+  const FileStorageDelegate();
+
+  /// Whether the application uses scoped storage,
+  /// which limits the access to top-level directories.
+  Future<bool> hasScopedStorage();
+
+  /// Register the given [file] as a new document.
+  ///
+  /// Throws if the file is empty or an invalid format.
+  Future<void> registerDocument(File file);
+
+  /// Request permission to write to external storage.
+  ///
+  /// This permission only has an effect on Android 9 and lower,
+  /// where Scoped Storage is not in effect.
+  Future<bool> requestWriteExternalStoragePermission();
+}

--- a/lib/native_service/io_file_storage_delegate.dart
+++ b/lib/native_service/io_file_storage_delegate.dart
@@ -2,15 +2,12 @@ import 'dart:io';
 
 import 'package:mime/mime.dart';
 import 'package:path/path.dart';
-import 'package:weforza/native_service/native_service.dart';
+import 'package:weforza/native_service/file_storage_delegate.dart';
 
-/// This class represents a service that provides a mechanism
-/// to register new files in the underlying file provider.
-final class FileProvider extends NativeService {
-  const FileProvider();
+final class IoFileStorageDelegate extends FileStorageDelegate {
+  const IoFileStorageDelegate();
 
-  /// Whether the application uses Scoped Storage.
-  /// This only has an effect on Android.
+  @override
   Future<bool> hasScopedStorage() async {
     if (Platform.isAndroid) {
       return await methodChannel.invokeMethod<bool>('hasScopedStorage') ?? false;
@@ -19,9 +16,7 @@ final class FileProvider extends NativeService {
     return false;
   }
 
-  /// Register the given [file] as a new document.
-  ///
-  /// Throws if the file is empty or an invalid format.
+  @override
   Future<void> registerDocument(File file) async {
     final String? mimeType = lookupMimeType(file.path);
     final int fileSize = file.lengthSync();
@@ -51,9 +46,7 @@ final class FileProvider extends NativeService {
     }
   }
 
-  /// Request permission to write to external storage.
-  ///
-  /// This permission only has an effect on Android 9 and lower, where Scoped Storage is not in effect.
+  @override
   Future<bool> requestWriteExternalStoragePermission() async {
     final bool? result = await methodChannel.invokeMethod<bool>(
       'requestWriteExternalStoragePermission',

--- a/lib/riverpod/file_storage_delegate_provider.dart
+++ b/lib/riverpod/file_storage_delegate_provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:weforza/native_service/file_storage_delegate.dart';
+import 'package:weforza/native_service/io_file_storage_delegate.dart';
+
+/// This provider provides a [FileStorageDelegate] for managing files with the underlying file provider.
+///
+/// Since the provided delegate here is constant,
+/// it is the same object as the one used in the initialization at the top of `void main() {}`.
+final fileStorageDelegateProvider = Provider<FileStorageDelegate>((_) => const IoFileStorageDelegate());

--- a/lib/widgets/pages/export_data_page/export_ride_page.dart
+++ b/lib/widgets/pages/export_data_page/export_ride_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/model/export/export_rides_delegate.dart';
 import 'package:weforza/model/ride.dart';
+import 'package:weforza/riverpod/file_storage_delegate_provider.dart';
 import 'package:weforza/riverpod/file_system_provider.dart';
 import 'package:weforza/riverpod/repository/export_rides_repository_provider.dart';
 import 'package:weforza/widgets/custom/animated_circle_checkmark.dart';
@@ -39,6 +40,7 @@ class _ExportRidePageState extends ConsumerState<ExportRidePage> with SingleTick
   void initState() {
     super.initState();
     _delegate = ExportRidesDelegate(
+      fileStorageDelegate: ref.read(fileStorageDelegateProvider),
       fileSystem: ref.read(fileSystemProvider),
       repository: ref.read(exportRidesRepositoryProvider),
     );

--- a/lib/widgets/pages/export_data_page/export_riders_page.dart
+++ b/lib/widgets/pages/export_data_page/export_riders_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/model/export/export_riders_delegate.dart';
+import 'package:weforza/riverpod/file_storage_delegate_provider.dart';
 import 'package:weforza/riverpod/file_system_provider.dart';
 import 'package:weforza/riverpod/repository/serialize_riders_repository_provider.dart';
 import 'package:weforza/widgets/custom/animated_circle_checkmark.dart';
@@ -23,6 +24,7 @@ class _ExportRidersPageState extends ConsumerState<ExportRidersPage> with Single
   void initState() {
     super.initState();
     _delegate = ExportRidersDelegate(
+      fileStorageDelegate: ref.read(fileStorageDelegateProvider),
       fileSystem: ref.read(fileSystemProvider),
       serializeRidersRepository: ref.read(serializeRidersRepositoryProvider),
     );


### PR DESCRIPTION
This PR cleans up the rather unfortunate name of the old `FileProvider` and moves it behind an interface.