### PR TITLE
Audit uses of `dart:io`

### DIFF
--- a/lib/file/file_system.dart
+++ b/lib/file/file_system.dart
@@ -24,4 +24,9 @@ abstract interface class FileSystem {
 
   /// Get a reference to a [fs.File] at the given [path].
   fs.File file(String path);
+
+  /// Get a reference to a [fs.File] from the given [uri].
+  ///
+  /// Throws an [ArgumentError] if the given [uri] is not a `file://` Uri.
+  fs.File fileFromUri(Uri uri);
 }

--- a/lib/file/file_uri_parser.dart
+++ b/lib/file/file_uri_parser.dart
@@ -1,6 +1,5 @@
-import 'dart:io' show Platform;
-
 import 'package:file/file.dart' as fs;
+import 'package:os_detect/os_detect.dart' as platform;
 import 'package:weforza/file/file_system.dart';
 
 /// This class parses a path to a file into a valid [Uri].
@@ -29,7 +28,7 @@ final class FileUriParser {
     }
 
     // Only Android supports `content://` Uris.
-    if (Platform.isAndroid && uri.isScheme('content')) {
+    if (platform.isAndroid && uri.isScheme('content')) {
       return uri;
     }
 

--- a/lib/file/import_riders_csv_reader.dart
+++ b/lib/file/import_riders_csv_reader.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-import 'dart:io';
 
+import 'package:file/file.dart' as fs;
 import 'package:weforza/file/import_riders_file_reader.dart';
 import 'package:weforza/model/device/device.dart';
 import 'package:weforza/model/rider/rider.dart';
@@ -133,7 +133,7 @@ class ImportRidersCsvReader implements ImportRidersFileReader<String> {
   }
 
   @override
-  Future<List<String>> readFile(File file) async {
+  Future<List<String>> readFile(fs.File file) async {
     final lines = await file.openRead().transform(utf8.decoder).transform(const LineSplitter()).toList();
 
     if (lines.isEmpty) {

--- a/lib/file/import_riders_file_reader.dart
+++ b/lib/file/import_riders_file_reader.dart
@@ -1,5 +1,4 @@
-import 'dart:io';
-
+import 'package:file/file.dart' as fs;
 import 'package:weforza/model/rider/serializable_rider.dart';
 
 /// This interface defines a file reader for importing a rider data source file.
@@ -13,5 +12,5 @@ abstract class ImportRidersFileReader<T> {
   /// Returns the file contents in readable chunks.
   ///
   /// Throws a [FormatException] if the file is malformed.
-  Future<List<T>> readFile(File file);
+  Future<List<T>> readFile(fs.File file);
 }

--- a/lib/file/import_riders_json_reader.dart
+++ b/lib/file/import_riders_json_reader.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
-import 'dart:io';
-
+import 'package:file/file.dart' as fs;
 import 'package:weforza/file/import_riders_file_reader.dart';
 import 'package:weforza/model/device/device.dart';
 import 'package:weforza/model/rider/rider.dart';
@@ -49,7 +48,7 @@ class ImportRidersJsonReader implements ImportRidersFileReader<Map<String, dynam
   }
 
   @override
-  Future<List<Map<String, dynamic>>> readFile(File file) async {
+  Future<List<Map<String, dynamic>>> readFile(fs.File file) async {
     final fileContent = await file.readAsString();
 
     try {

--- a/lib/file/io_file_system.dart
+++ b/lib/file/io_file_system.dart
@@ -1,6 +1,8 @@
-import 'dart:io' as io show Directory, Platform;
+import 'dart:io' as io show Directory;
+
 import 'package:file/file.dart' as fs;
 import 'package:file/local.dart';
+import 'package:os_detect/os_detect.dart' as platform;
 import 'package:path_provider/path_provider.dart';
 import 'package:weforza/file/file_system.dart';
 import 'package:weforza/native_service/file_storage_delegate.dart';
@@ -58,7 +60,7 @@ class IoFileSystem implements FileSystem {
 
     // Android only has top level directories when Scoped Storage is not being used,
     // while iOS does not have accessible top level directories.
-    if (io.Platform.isAndroid && !hasScopedStorage) {
+    if (platform.isAndroid && !hasScopedStorage) {
       topLevelDocumentDirectories = await getExternalStorageDirectories(type: StorageDirectory.documents);
     }
 

--- a/lib/file/io_file_system.dart
+++ b/lib/file/io_file_system.dart
@@ -39,6 +39,15 @@ class IoFileSystem implements FileSystem {
   @override
   fs.File file(String path) => _fileSystem.file(path);
 
+  @override
+  fs.File fileFromUri(Uri uri) {
+    if (!uri.isScheme('file')) {
+      throw ArgumentError.value(uri, 'uri', 'The given Uri is not a "file://" Uri.');
+    }
+
+    return _fileSystem.file(uri);
+  }
+
   /// Set up the file system by loading the necessary directory information.
   void _initialize(FileStorageDelegate fileStorageDelegate) async {
     documentsDirectory = await getApplicationDocumentsDirectory().then(_fileSystem.directory);

--- a/lib/model/export/export_delegate.dart
+++ b/lib/model/export/export_delegate.dart
@@ -1,7 +1,6 @@
-import 'dart:io' show Platform;
-
 import 'package:file/file.dart' as fs;
 import 'package:flutter/widgets.dart';
+import 'package:os_detect/os_detect.dart' as platform;
 import 'package:path/path.dart';
 import 'package:rxdart/subjects.dart';
 import 'package:weforza/exceptions/exceptions.dart';
@@ -80,7 +79,7 @@ abstract class ExportDelegate<Options> extends AsyncComputationDelegate<void> {
 
       // On iOS, the exported files are saved to the application documents directory.
       // Check if the file does not exist yet, and write to the file.
-      if (Platform.isIOS) {
+      if (platform.isIOS) {
         final fs.Directory directory = fileSystem.documentsDirectory;
 
         final fs.File file = fileSystem.file(join(directory.path, fileName));
@@ -96,7 +95,7 @@ abstract class ExportDelegate<Options> extends AsyncComputationDelegate<void> {
         return;
       }
 
-      if (Platform.isAndroid) {
+      if (platform.isAndroid) {
         final fs.File file;
 
         if (fileSystem.hasScopedStorage) {

--- a/lib/model/image/io_pick_image_delegate.dart
+++ b/lib/model/image/io_pick_image_delegate.dart
@@ -1,7 +1,6 @@
-import 'dart:io' show Platform;
-
 import 'package:file/file.dart' as fs;
 import 'package:image_picker/image_picker.dart';
+import 'package:os_detect/os_detect.dart' as platform;
 import 'package:path/path.dart';
 import 'package:weforza/exceptions/exceptions.dart';
 import 'package:weforza/file/file_system.dart';
@@ -32,7 +31,7 @@ class IoPickImageDelegate implements PickImageDelegate {
   ///
   /// If any permission is not granted, this returns a [Future.error].
   Future<void> _requestCameraAndPhotoLibraryPermissions() async {
-    if (Platform.isAndroid || Platform.isIOS) {
+    if (platform.isAndroid || platform.isIOS) {
       final bool hasCameraPermission = await mediaPermissionsDelegate.requestCameraPermission();
 
       if (!hasCameraPermission) {
@@ -40,7 +39,7 @@ class IoPickImageDelegate implements PickImageDelegate {
       }
     }
 
-    if (Platform.isAndroid && !fileSystem.hasScopedStorage) {
+    if (platform.isAndroid && !fileSystem.hasScopedStorage) {
       // Request only write permission for external storage.
       // This permission is required to save the image.
       // The read permission is not required, since reading a content Uri happens through the MediaStore.
@@ -51,7 +50,7 @@ class IoPickImageDelegate implements PickImageDelegate {
       }
     }
 
-    if (Platform.isIOS) {
+    if (platform.isIOS) {
       final bool hasPhotosPermission = await mediaPermissionsDelegate.requestAddToPhotoLibraryPermission();
 
       if (!hasPhotosPermission) {
@@ -80,7 +79,7 @@ class IoPickImageDelegate implements PickImageDelegate {
       return null;
     }
 
-    if (Platform.isAndroid) {
+    if (platform.isAndroid) {
       final Uri? mediaStoreUri = await fileStorageDelegate.registerImage(fileSystem.file(profileImage.path));
 
       if (mediaStoreUri == null) {
@@ -95,7 +94,7 @@ class IoPickImageDelegate implements PickImageDelegate {
     // This directory is accessible for the application, so no extra permissions are required.
     // After the image is saved, register it with the Photos app,
     // so that it is retained when the application is uninstalled.
-    if (Platform.isIOS) {
+    if (platform.isIOS) {
       final fs.Directory directory = fileSystem.documentsDirectory;
 
       final fs.File destinationFile = fileSystem.file(join(directory.path, profileImage.name));

--- a/lib/model/import/import_riders_delegate.dart
+++ b/lib/model/import/import_riders_delegate.dart
@@ -1,5 +1,4 @@
-import 'dart:io';
-
+import 'package:file/file.dart' as fs;
 import 'package:rxdart/rxdart.dart';
 import 'package:weforza/exceptions/exceptions.dart';
 import 'package:weforza/file/import_riders_csv_reader.dart';
@@ -26,7 +25,7 @@ class ImportRidersDelegate {
   Stream<ImportRidersState> get stream => _controller;
 
   Future<Iterable<SerializableRider>> _readFileWithReader<T>(
-    File file, {
+    fs.File file, {
     required ImportRidersFileReader<T> reader,
   }) async {
     final items = <SerializableRider>[];
@@ -50,7 +49,7 @@ class ImportRidersDelegate {
   /// Returns the collection of [SerializableRider]s.
   ///
   /// Throws a [FormatException] if the file is malformed.
-  Future<Iterable<SerializableRider>> _readRidersFromFile(File file) async {
+  Future<Iterable<SerializableRider>> _readRidersFromFile(fs.File file) async {
     if (file.path.endsWith(ExportFileFormat.csv.formatExtension)) {
       return _readFileWithReader<String>(
         file,

--- a/lib/native_service/file_storage_delegate.dart
+++ b/lib/native_service/file_storage_delegate.dart
@@ -1,6 +1,6 @@
-import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:file/file.dart' as fs;
 import 'package:weforza/native_service/native_service.dart';
 
 /// This class defines an interface that allows working with the underlying file provider.
@@ -17,14 +17,14 @@ abstract base class FileStorageDelegate extends NativeService {
   /// Register the given [file] as a new document.
   ///
   /// Throws if the file is empty or an invalid format.
-  Future<void> registerDocument(File file);
+  Future<void> registerDocument(fs.File file);
 
   /// Register the given [file] as a new image.
   ///
   /// Returns the [Uri] to the registered image or null if no Uri is available.
   ///
   /// Throws if the file is empty or an invalid format.
-  Future<Uri?> registerImage(File file);
+  Future<Uri?> registerImage(fs.File file);
 
   /// Request permission to write to external storage.
   ///

--- a/lib/native_service/io_file_storage_delegate.dart
+++ b/lib/native_service/io_file_storage_delegate.dart
@@ -1,4 +1,4 @@
-import 'dart:io';
+import 'dart:io' show Platform;
 import 'dart:typed_data';
 
 import 'package:file/file.dart' as fs;

--- a/lib/native_service/io_file_storage_delegate.dart
+++ b/lib/native_service/io_file_storage_delegate.dart
@@ -1,9 +1,8 @@
-import 'dart:io' show Platform;
 import 'dart:typed_data';
 
 import 'package:file/file.dart' as fs;
-
 import 'package:mime/mime.dart';
+import 'package:os_detect/os_detect.dart' as platform;
 import 'package:path/path.dart';
 import 'package:weforza/native_service/file_storage_delegate.dart';
 
@@ -12,7 +11,7 @@ final class IoFileStorageDelegate extends FileStorageDelegate {
 
   @override
   Future<bool> hasScopedStorage() async {
-    if (Platform.isAndroid) {
+    if (platform.isAndroid) {
       return await methodChannel.invokeMethod<bool>('hasScopedStorage') ?? false;
     }
 
@@ -51,7 +50,7 @@ final class IoFileStorageDelegate extends FileStorageDelegate {
 
   @override
   Future<bool> requestWriteExternalStoragePermission() async {
-    if (!Platform.isAndroid) {
+    if (!platform.isAndroid) {
       throw UnsupportedError('External storage is only supported on Android.');
     }
 
@@ -88,7 +87,7 @@ final class IoFileStorageDelegate extends FileStorageDelegate {
 
   @override
   Future<Uint8List> getBytesFromContentUri(Uri uri) async {
-    if (!Platform.isAndroid) {
+    if (!platform.isAndroid) {
       throw UnsupportedError('Loading a "content://" Uri is only supported on Android.');
     }
 

--- a/lib/native_service/io_file_storage_delegate.dart
+++ b/lib/native_service/io_file_storage_delegate.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:file/file.dart' as fs;
+
 import 'package:mime/mime.dart';
 import 'package:path/path.dart';
 import 'package:weforza/native_service/file_storage_delegate.dart';
@@ -18,7 +20,7 @@ final class IoFileStorageDelegate extends FileStorageDelegate {
   }
 
   @override
-  Future<void> registerDocument(File file) async {
+  Future<void> registerDocument(fs.File file) async {
     final String? mimeType = lookupMimeType(file.path);
     final int fileSize = file.lengthSync();
 
@@ -59,7 +61,7 @@ final class IoFileStorageDelegate extends FileStorageDelegate {
   }
 
   @override
-  Future<Uri?> registerImage(File file) async {
+  Future<Uri?> registerImage(fs.File file) async {
     final String mimeType = lookupMimeType(file.path) ?? '';
     final int fileSize = file.lengthSync();
 

--- a/lib/widgets/custom/profile_image/profile_image.dart
+++ b/lib/widgets/custom/profile_image/profile_image.dart
@@ -1,11 +1,11 @@
-import 'dart:io';
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weforza/file/content_uri_image_provider.dart';
+import 'package:weforza/file/file_system.dart';
 import 'package:weforza/riverpod/file/file_storage_delegate_provider.dart';
+import 'package:weforza/riverpod/file/file_system_provider.dart';
 
 /// This widget represents a profile image.
 class ProfileImage extends StatelessWidget {
@@ -61,14 +61,20 @@ class ProfileImage extends StatelessWidget {
     }
 
     if (imageUri.isScheme('file')) {
-      return Image.file(
-        File.fromUri(imageUri),
-        width: size,
-        height: size,
-        fit: BoxFit.cover,
-        errorBuilder: (context, error, stackTrace) => placeholder,
-        frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
-          return frame == null ? loading ?? placeholder : ClipOval(child: child);
+      return Consumer(
+        builder: (context, ref, child) {
+          final FileSystem fileSystem = ref.read(fileSystemProvider);
+
+          return Image.file(
+            fileSystem.fileFromUri(imageUri),
+            width: size,
+            height: size,
+            fit: BoxFit.cover,
+            errorBuilder: (context, error, stackTrace) => placeholder,
+            frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
+              return frame == null ? loading ?? placeholder : ClipOval(child: child);
+            },
+          );
         },
       );
     }

--- a/lib/widgets/pages/export_data_page/export_data_file_name_text_field.dart
+++ b/lib/widgets/pages/export_data_page/export_data_file_name_text_field.dart
@@ -1,9 +1,8 @@
-import 'dart:io' show Platform;
-
 import 'package:file/file.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:os_detect/os_detect.dart' as platform;
 import 'package:path/path.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/model/export/export_delegate.dart';
@@ -51,7 +50,7 @@ class ExportDataFileNameTextField<T> extends StatelessWidget {
       );
     }
 
-    if (Platform.isAndroid) {
+    if (platform.isAndroid) {
       // When ScopedStorage is enabled, the MediaStore handles duplicate filenames internally.
       if (delegate.fileSystem.hasScopedStorage) {
         return null;
@@ -70,7 +69,7 @@ class ExportDataFileNameTextField<T> extends StatelessWidget {
     }
 
     // On iOS, the exported files are saved to the application documents directory.
-    if (Platform.isIOS) {
+    if (platform.isIOS) {
       final Directory directory = delegate.fileSystem.documentsDirectory;
 
       if (delegate.fileSystem.file(join(directory.path, fileName)).existsSync()) {

--- a/lib/widgets/pages/export_data_page/export_data_page.dart
+++ b/lib/widgets/pages/export_data_page/export_data_page.dart
@@ -1,8 +1,7 @@
-import 'dart:io' show Platform;
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:os_detect/os_detect.dart' as platform;
 import 'package:weforza/exceptions/exceptions.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/model/export/export_delegate.dart';
@@ -221,7 +220,7 @@ class _ExportPageDoneIndicator extends StatelessWidget {
     final S translator = S.of(context);
     final String message;
 
-    if (Platform.isAndroid && !hasAndroidScopedStorage) {
+    if (platform.isAndroid && !hasAndroidScopedStorage) {
       message = translator.exportedFileAvailableInDownloads;
     } else {
       message = translator.exportedFileAvailableInDocuments;

--- a/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
@@ -1,4 +1,4 @@
-import 'dart:io';
+import 'dart:io' show Platform;
 
 import 'package:app_settings/app_settings.dart';
 import 'package:flutter/cupertino.dart';

--- a/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
@@ -1,8 +1,7 @@
-import 'dart:io' show Platform;
-
 import 'package:app_settings/app_settings.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:os_detect/os_detect.dart' as platform;
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/widgets/common/generic_error.dart';
 import 'package:weforza/widgets/platform/platform_aware_icon.dart';
@@ -95,7 +94,7 @@ class PermissionDeniedError extends StatelessWidget {
     // Without the location permission, the scan cannot find devices.
     //
     // On other platforms (i.e. iOS) the location permission is not required.
-    if (Platform.isAndroid) {
+    if (platform.isAndroid) {
       errorMessage = translator.scanAbortedBluetoothAndLocationPermissionDenied;
     } else {
       errorMessage = translator.scanAbortedBluetoothPermissionDenied;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -428,6 +428,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  os_detect:
+    dependency: "direct main"
+    description:
+      name: os_detect
+      sha256: faf3bcf39515e64da8ff76b2f2805b20a6ff47ae515393e535f8579ff91d6b7f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,9 @@ dependencies:
   # This package provies MIME-type lookup utilities.
   mime: ^1.0.4
 
+  # This package provides a platform independent way to access the current platform.
+  os_detect: ^2.0.1
+
   # package_info_plus provides access to app specific information such as build number & version.
   package_info_plus: ^4.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   # This package provies MIME-type lookup utilities.
   mime: ^1.0.4
 
-  # This package provides a platform independent way to access the current platform.
+  # This package provides a way to access the current platform, that is safe for the web as well.
   os_detect: ^2.0.1
 
   # package_info_plus provides access to app specific information such as build number & version.


### PR DESCRIPTION
This PR audits the uses of `dart:io`. Now it is only used internally in `IoFileSystem` once (albeit indirectly and for one local variable). The other usages have been migrated to `package:file` for files and directories and `paxkage:os_detect` for the `Platform.isAndroid` and friends.

Fixes #403 