### PR TITLE
revert usage of os_detect

### DIFF
--- a/lib/file/file_uri_parser.dart
+++ b/lib/file/file_uri_parser.dart
@@ -1,5 +1,6 @@
+import 'dart:io' show Platform;
+
 import 'package:file/file.dart' as fs;
-import 'package:os_detect/os_detect.dart' as platform;
 import 'package:weforza/file/file_system.dart';
 
 /// This class parses a path to a file into a valid [Uri].
@@ -28,7 +29,7 @@ final class FileUriParser {
     }
 
     // Only Android supports `content://` Uris.
-    if (platform.isAndroid && uri.isScheme('content')) {
+    if (Platform.isAndroid && uri.isScheme('content')) {
       return uri;
     }
 

--- a/lib/file/io_file_system.dart
+++ b/lib/file/io_file_system.dart
@@ -1,8 +1,7 @@
-import 'dart:io' as io show Directory;
+import 'dart:io' as io show Directory, Platform;
 
 import 'package:file/file.dart' as fs;
 import 'package:file/local.dart';
-import 'package:os_detect/os_detect.dart' as platform;
 import 'package:path_provider/path_provider.dart';
 import 'package:weforza/file/file_system.dart';
 import 'package:weforza/native_service/file_storage_delegate.dart';
@@ -60,7 +59,7 @@ class IoFileSystem implements FileSystem {
 
     // Android only has top level directories when Scoped Storage is not being used,
     // while iOS does not have accessible top level directories.
-    if (platform.isAndroid && !hasScopedStorage) {
+    if (io.Platform.isAndroid && !hasScopedStorage) {
       topLevelDocumentDirectories = await getExternalStorageDirectories(type: StorageDirectory.documents);
     }
 

--- a/lib/model/export/export_delegate.dart
+++ b/lib/model/export/export_delegate.dart
@@ -1,6 +1,7 @@
+import 'dart:io' show Platform;
+
 import 'package:file/file.dart' as fs;
 import 'package:flutter/widgets.dart';
-import 'package:os_detect/os_detect.dart' as platform;
 import 'package:path/path.dart';
 import 'package:rxdart/subjects.dart';
 import 'package:weforza/exceptions/exceptions.dart';
@@ -79,7 +80,7 @@ abstract class ExportDelegate<Options> extends AsyncComputationDelegate<void> {
 
       // On iOS, the exported files are saved to the application documents directory.
       // Check if the file does not exist yet, and write to the file.
-      if (platform.isIOS) {
+      if (Platform.isIOS) {
         final fs.Directory directory = fileSystem.documentsDirectory;
 
         final fs.File file = fileSystem.file(join(directory.path, fileName));
@@ -95,7 +96,7 @@ abstract class ExportDelegate<Options> extends AsyncComputationDelegate<void> {
         return;
       }
 
-      if (platform.isAndroid) {
+      if (Platform.isAndroid) {
         final fs.File file;
 
         if (fileSystem.hasScopedStorage) {

--- a/lib/model/image/io_pick_image_delegate.dart
+++ b/lib/model/image/io_pick_image_delegate.dart
@@ -1,6 +1,7 @@
+import 'dart:io' show Platform;
+
 import 'package:file/file.dart' as fs;
 import 'package:image_picker/image_picker.dart';
-import 'package:os_detect/os_detect.dart' as platform;
 import 'package:path/path.dart';
 import 'package:weforza/exceptions/exceptions.dart';
 import 'package:weforza/file/file_system.dart';
@@ -31,7 +32,7 @@ class IoPickImageDelegate implements PickImageDelegate {
   ///
   /// If any permission is not granted, this returns a [Future.error].
   Future<void> _requestCameraAndPhotoLibraryPermissions() async {
-    if (platform.isAndroid || platform.isIOS) {
+    if (Platform.isAndroid || Platform.isIOS) {
       final bool hasCameraPermission = await mediaPermissionsDelegate.requestCameraPermission();
 
       if (!hasCameraPermission) {
@@ -39,7 +40,7 @@ class IoPickImageDelegate implements PickImageDelegate {
       }
     }
 
-    if (platform.isAndroid && !fileSystem.hasScopedStorage) {
+    if (Platform.isAndroid && !fileSystem.hasScopedStorage) {
       // Request only write permission for external storage.
       // This permission is required to save the image.
       // The read permission is not required, since reading a content Uri happens through the MediaStore.
@@ -50,7 +51,7 @@ class IoPickImageDelegate implements PickImageDelegate {
       }
     }
 
-    if (platform.isIOS) {
+    if (Platform.isIOS) {
       final bool hasPhotosPermission = await mediaPermissionsDelegate.requestAddToPhotoLibraryPermission();
 
       if (!hasPhotosPermission) {
@@ -79,7 +80,7 @@ class IoPickImageDelegate implements PickImageDelegate {
       return null;
     }
 
-    if (platform.isAndroid) {
+    if (Platform.isAndroid) {
       final Uri? mediaStoreUri = await fileStorageDelegate.registerImage(fileSystem.file(profileImage.path));
 
       if (mediaStoreUri == null) {
@@ -94,7 +95,7 @@ class IoPickImageDelegate implements PickImageDelegate {
     // This directory is accessible for the application, so no extra permissions are required.
     // After the image is saved, register it with the Photos app,
     // so that it is retained when the application is uninstalled.
-    if (platform.isIOS) {
+    if (Platform.isIOS) {
       final fs.Directory directory = fileSystem.documentsDirectory;
 
       final fs.File destinationFile = fileSystem.file(join(directory.path, profileImage.name));

--- a/lib/native_service/io_file_storage_delegate.dart
+++ b/lib/native_service/io_file_storage_delegate.dart
@@ -1,8 +1,8 @@
+import 'dart:io' show Platform;
 import 'dart:typed_data';
 
 import 'package:file/file.dart' as fs;
 import 'package:mime/mime.dart';
-import 'package:os_detect/os_detect.dart' as platform;
 import 'package:path/path.dart';
 import 'package:weforza/native_service/file_storage_delegate.dart';
 
@@ -11,7 +11,7 @@ final class IoFileStorageDelegate extends FileStorageDelegate {
 
   @override
   Future<bool> hasScopedStorage() async {
-    if (platform.isAndroid) {
+    if (Platform.isAndroid) {
       return await methodChannel.invokeMethod<bool>('hasScopedStorage') ?? false;
     }
 
@@ -50,7 +50,7 @@ final class IoFileStorageDelegate extends FileStorageDelegate {
 
   @override
   Future<bool> requestWriteExternalStoragePermission() async {
-    if (!platform.isAndroid) {
+    if (!Platform.isAndroid) {
       throw UnsupportedError('External storage is only supported on Android.');
     }
 
@@ -87,7 +87,7 @@ final class IoFileStorageDelegate extends FileStorageDelegate {
 
   @override
   Future<Uint8List> getBytesFromContentUri(Uri uri) async {
-    if (!platform.isAndroid) {
+    if (!Platform.isAndroid) {
       throw UnsupportedError('Loading a "content://" Uri is only supported on Android.');
     }
 

--- a/lib/widgets/pages/export_data_page/export_data_file_name_text_field.dart
+++ b/lib/widgets/pages/export_data_page/export_data_file_name_text_field.dart
@@ -1,8 +1,9 @@
+import 'dart:io' show Platform;
+
 import 'package:file/file.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:os_detect/os_detect.dart' as platform;
 import 'package:path/path.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/model/export/export_delegate.dart';
@@ -50,7 +51,7 @@ class ExportDataFileNameTextField<T> extends StatelessWidget {
       );
     }
 
-    if (platform.isAndroid) {
+    if (Platform.isAndroid) {
       // When ScopedStorage is enabled, the MediaStore handles duplicate filenames internally.
       if (delegate.fileSystem.hasScopedStorage) {
         return null;
@@ -69,7 +70,7 @@ class ExportDataFileNameTextField<T> extends StatelessWidget {
     }
 
     // On iOS, the exported files are saved to the application documents directory.
-    if (platform.isIOS) {
+    if (Platform.isIOS) {
       final Directory directory = delegate.fileSystem.documentsDirectory;
 
       if (delegate.fileSystem.file(join(directory.path, fileName)).existsSync()) {

--- a/lib/widgets/pages/export_data_page/export_data_page.dart
+++ b/lib/widgets/pages/export_data_page/export_data_page.dart
@@ -1,7 +1,8 @@
+import 'dart:io' show Platform;
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:os_detect/os_detect.dart' as platform;
 import 'package:weforza/exceptions/exceptions.dart';
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/model/export/export_delegate.dart';
@@ -220,7 +221,7 @@ class _ExportPageDoneIndicator extends StatelessWidget {
     final S translator = S.of(context);
     final String message;
 
-    if (platform.isAndroid && !hasAndroidScopedStorage) {
+    if (Platform.isAndroid && !hasAndroidScopedStorage) {
       message = translator.exportedFileAvailableInDownloads;
     } else {
       message = translator.exportedFileAvailableInDocuments;

--- a/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/generic_scan_error.dart
@@ -1,7 +1,8 @@
+import 'dart:io' show Platform;
+
 import 'package:app_settings/app_settings.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:os_detect/os_detect.dart' as platform;
 import 'package:weforza/generated/l10n.dart';
 import 'package:weforza/widgets/common/generic_error.dart';
 import 'package:weforza/widgets/platform/platform_aware_icon.dart';
@@ -94,7 +95,7 @@ class PermissionDeniedError extends StatelessWidget {
     // Without the location permission, the scan cannot find devices.
     //
     // On other platforms (i.e. iOS) the location permission is not required.
-    if (platform.isAndroid) {
+    if (Platform.isAndroid) {
       errorMessage = translator.scanAbortedBluetoothAndLocationPermissionDenied;
     } else {
       errorMessage = translator.scanAbortedBluetoothPermissionDenied;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -428,14 +428,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
-  os_detect:
-    dependency: "direct main"
-    description:
-      name: os_detect
-      sha256: faf3bcf39515e64da8ff76b2f2805b20a6ff47ae515393e535f8579ff91d6b7f
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,9 +54,6 @@ dependencies:
   # This package provies MIME-type lookup utilities.
   mime: ^1.0.4
 
-  # This package provides a way to access the current platform, that is safe for the web as well.
-  os_detect: ^2.0.1
-
   # package_info_plus provides access to app specific information such as build number & version.
   package_info_plus: ^4.0.0
 


### PR DESCRIPTION
This PR reverts the usage of `os_detect`. The app is not intended to be compiled for the web.

Regardless, if it was, a `kIsWeb` check before using `Platform` would be sufficient.