### PR TITLE
bump gradle & Flutter version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,8 +24,8 @@ if (flutterVersionName == null) {
 
 android {
     namespace "be.weforza.app"
-    compileSdkVersion 34
-    ndkVersion flutter.ndkVersion
+    compileSdk 34
+    ndkVersion "26.1.10909125"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
@@ -43,8 +43,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "be.weforza.app"
-        minSdkVersion 21
-        targetSdkVersion 34
+        minSdk 21
+        targetSdk 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -64,7 +64,6 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "androidx.core:core-splashscreen:$splash_screen_version"
-    implementation "androidx.core:core-ktx:$androidx_core_version"
+    implementation "androidx.core:core-splashscreen:1.0.1"
+    implementation "androidx.core:core-ktx:1.10.1"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,22 +1,3 @@
-buildscript {
-    ext {
-        kotlin_version = '1.8.22'
-        gradle_version = '8.0.1'
-        splash_screen_version = '1.0.1'
-        androidx_core_version =  '1.10.1'
-    }
-
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath "com.android.tools.build:gradle:$gradle_version"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -5,12 +5,21 @@ pluginManagement {
         def flutterSdkPath = properties.getProperty("flutter.sdk")
         assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
         return flutterSdkPath
-    }
-    settings.ext.flutterSdkPath = flutterSdkPath()
+    }()
 
-    includeBuild("${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle")
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
+
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.4.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 
 include ":app"
-
-apply from: "${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle/app_plugin_loader.gradle"

--- a/lib/widgets/pages/settings/excluded_terms/excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/excluded_term_input_field.dart
@@ -85,9 +85,9 @@ class ExcludedTermInputField extends StatelessWidget {
               final ColorScheme colorScheme = Theme.of(context).colorScheme;
               Color color = const Color(0xFFD5D5D5);
 
-              if (states.contains(MaterialState.error)) {
+              if (states.contains(WidgetState.error)) {
                 color = colorScheme.error;
-              } else if (states.contains(MaterialState.focused)) {
+              } else if (states.contains(WidgetState.focused)) {
                 color = colorScheme.primary;
               }
 

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -34,12 +34,12 @@ abstract class AppTheme {
       navigationBarTheme: NavigationBarThemeData(
         indicatorColor: navigationBarIndicatorColor,
         labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
-        iconTheme: MaterialStateProperty.resolveWith<IconThemeData>((states) {
+        iconTheme: WidgetStateProperty.resolveWith<IconThemeData>((states) {
           switch (brightness) {
             case Brightness.dark:
               return IconThemeData(
                 size: 24,
-                color: states.contains(MaterialState.selected) ? colorScheme.primary : colorScheme.onSurface,
+                color: states.contains(WidgetState.selected) ? colorScheme.primary : colorScheme.onSurface,
               );
             case Brightness.light:
               return IconThemeData(size: 24, color: colorScheme.onSurface);
@@ -60,15 +60,15 @@ abstract class AppTheme {
       ],
       segmentedButtonTheme: SegmentedButtonThemeData(
         style: ButtonStyle(
-          backgroundColor: MaterialStateProperty.resolveWith((states) {
-            if (states.contains(MaterialState.selected)) {
+          backgroundColor: WidgetStateProperty.resolveWith((states) {
+            if (states.contains(WidgetState.selected)) {
               return colorScheme.primary;
             }
 
             return null;
           }),
-          foregroundColor: MaterialStateProperty.resolveWith((states) {
-            if (states.contains(MaterialState.selected)) {
+          foregroundColor: WidgetStateProperty.resolveWith((states) {
+            if (states.contains(WidgetState.selected)) {
               return colorScheme.onPrimary;
             }
 
@@ -195,10 +195,10 @@ class RideCalendarTheme {
               theme.brightness,
               dark: RideCalendarTheme.filled(
                 backgroundColor: colorScheme.onSurfaceVariant,
-                labelColor: colorScheme.surfaceVariant,
+                labelColor: colorScheme.surfaceContainerHighest,
               ),
               light: RideCalendarTheme.filled(
-                backgroundColor: colorScheme.surfaceVariant,
+                backgroundColor: colorScheme.surfaceContainerHighest,
                 labelColor: colorScheme.onSurfaceVariant,
               ),
             );
@@ -207,11 +207,11 @@ class RideCalendarTheme {
               theme.brightness,
               dark: RideCalendarTheme.filled(
                 backgroundColor: colorScheme.onSurface.withOpacity(0.36),
-                labelColor: colorScheme.onBackground,
+                labelColor: colorScheme.onSurface,
               ),
               light: RideCalendarTheme.filled(
                 backgroundColor: colorScheme.onSurfaceVariant,
-                labelColor: colorScheme.surfaceVariant,
+                labelColor: colorScheme.surfaceContainerHighest,
               ),
             );
         }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -360,10 +360,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.1"
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -384,26 +384,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -440,10 +440,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: "direct main"
     description:
@@ -733,26 +733,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: a1f7595805820fcc05e5c52e3a231aedd0b72972cb333e8c738a8b1239448b6f
+      sha256: "7ee446762c2c50b3bd4ea96fe13ffac69919352bd3b4b17bac3f3465edc58073"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.9"
+    version: "1.25.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: a757b14fc47507060a162cc2530d9a4a2f92f5100a952c7443b5cad5ef5b106a
+      sha256: "2bc4b4ecddd75309300d8096f781c0e3280ca1ef85beda558d33fcbedc2eead4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.9"
+    version: "0.6.0"
   typed_data:
     dependency: transitive
     description:
@@ -781,10 +781,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:
@@ -850,5 +850,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.0"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,8 +17,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.0"
+  sdk: ">=3.4.0 <4.0.0"
+  flutter: ">=3.22.0"
 
 dependencies:
   # This package provides easy access to app settings.


### PR DESCRIPTION
This PR applies the following changes:

- Bump Flutter to 3.22, which is the latest stable
- Bump Gradle & AGP to Android Studio Jellyfish compatible versions
- Fix a warning about an outdated NDK version
- Fix a warning about the deprecated apply script method
- Fix deprecated uses of compileSdkVersion and friends

Fixes #471 