### PR TITLE
Fix color scheme & text theme lookups

### DIFF
--- a/lib/widgets/common/device_icon.dart
+++ b/lib/widgets/common/device_icon.dart
@@ -17,7 +17,7 @@ class DeviceIcon extends StatelessWidget {
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        return Icon(type.icon, color: Theme.of(context).colorScheme.primary, size: size);
+        return Icon(type.icon, color: ColorScheme.of(context).primary, size: size);
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         return Icon(type.icon, color: CupertinoTheme.of(context).primaryColor, size: size);

--- a/lib/widgets/common/generic_error.dart
+++ b/lib/widgets/common/generic_error.dart
@@ -76,7 +76,7 @@ class GenericErrorLabel extends StatelessWidget {
     return PlatformAwareWidget(
       android: (context) {
         final child = DefaultTextStyle(
-          style: TextStyle(color: Theme.of(context).colorScheme.error, fontSize: 14),
+          style: TextStyle(color: ColorScheme.of(context).error, fontSize: 14),
           child: Text(message, softWrap: true),
         );
 

--- a/lib/widgets/common/progress_indicator_with_label.dart
+++ b/lib/widgets/common/progress_indicator_with_label.dart
@@ -19,7 +19,7 @@ class ProgressIndicatorWithLabel extends StatelessWidget {
             const CircularProgressIndicator(),
             Padding(
               padding: const EdgeInsets.only(top: 8),
-              child: Text(label, style: Theme.of(context).textTheme.labelMedium),
+              child: Text(label, style: TextTheme.of(context).labelMedium),
             ),
           ],
         );

--- a/lib/widgets/common/rider_attending_count.dart
+++ b/lib/widgets/common/rider_attending_count.dart
@@ -37,7 +37,7 @@ class _RiderAttendingCount extends StatelessWidget {
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        return Icon(Icons.directions_bike, color: Theme.of(context).colorScheme.primary);
+        return Icon(Icons.directions_bike, color: ColorScheme.of(context).primary);
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         return Icon(Icons.directions_bike, color: CupertinoTheme.of(context).primaryColor);

--- a/lib/widgets/custom/animated_circle_checkmark.dart
+++ b/lib/widgets/custom/animated_circle_checkmark.dart
@@ -63,7 +63,7 @@ class _AnimatedCircleCheckmarkState extends State<AnimatedCircleCheckmark> {
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        backgroundColor = Theme.of(context).colorScheme.primary;
+        backgroundColor = ColorScheme.of(context).primary;
         checkmarkIcon = Icons.check_rounded;
         break;
       case TargetPlatform.iOS:

--- a/lib/widgets/custom/device_type_carousel.dart
+++ b/lib/widgets/custom/device_type_carousel.dart
@@ -102,7 +102,7 @@ class _DeviceTypeCarouselDot extends StatelessWidget {
             break;
         }
 
-        color = selected ? theme.colorScheme.primary : disabledColor;
+        color = selected ? ColorScheme.of(context).primary : disabledColor;
         break;
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:

--- a/lib/widgets/custom/profile_image/profile_image.dart
+++ b/lib/widgets/custom/profile_image/profile_image.dart
@@ -117,7 +117,7 @@ class AdaptiveProfileImage extends StatelessWidget {
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         backgroundColors = Colors.primaries;
-        placeholderBackgroundColor = Theme.of(context).colorScheme.primary;
+        placeholderBackgroundColor = ColorScheme.of(context).primary;
         placeholderIcon = Icons.person;
         break;
       case TargetPlatform.iOS:

--- a/lib/widgets/custom/profile_image/profile_image_picker_placeholder.dart
+++ b/lib/widgets/custom/profile_image/profile_image_picker_placeholder.dart
@@ -59,7 +59,7 @@ class MaterialProfileImagePickerPlaceholder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final ColorScheme colorScheme = ColorScheme.of(context);
 
     return Container(
       height: size,

--- a/lib/widgets/pages/import_riders_page.dart
+++ b/lib/widgets/pages/import_riders_page.dart
@@ -142,8 +142,6 @@ class _ImportRidersButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
       android: (context) {
-        final theme = Theme.of(context);
-
         return Column(
           mainAxisAlignment: MainAxisAlignment.center,
           mainAxisSize: MainAxisSize.min,
@@ -161,7 +159,7 @@ class _ImportRidersButton extends StatelessWidget {
                 padding: const EdgeInsets.symmetric(horizontal: 20),
                 child: Text(
                   errorMessage ?? '',
-                  style: theme.textTheme.labelMedium!.copyWith(color: theme.colorScheme.error),
+                  style: TextTheme.of(context).labelMedium!.copyWith(color: ColorScheme.of(context).error),
                 ),
               ),
             ),

--- a/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_bottom_bar.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/manual_selection_list/manual_selection_bottom_bar.dart
@@ -28,7 +28,7 @@ class ManualSelectionBottomBar extends StatelessWidget {
   final Widget showScannedResultsToggle;
 
   Widget _buildAndroidLayout(BuildContext context, BoxConstraints constraints) {
-    final attendeeCounter = _buildAttendeeCounter(Icon(Icons.people, color: Theme.of(context).colorScheme.primary));
+    final attendeeCounter = _buildAttendeeCounter(Icon(Icons.people, color: ColorScheme.of(context).primary));
 
     final scannedResultsToggle = Row(
       mainAxisSize: MainAxisSize.min,

--- a/lib/widgets/pages/ride_attendee_scanning_page/scan_results_list.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/scan_results_list.dart
@@ -112,7 +112,7 @@ class _ScanResultsListItem extends StatelessWidget {
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        color = Theme.of(context).colorScheme.primary;
+        color = ColorScheme.of(context).primary;
         icon = Icons.person;
         break;
       case TargetPlatform.iOS:

--- a/lib/widgets/pages/ride_attendee_scanning_page/selectable_owner_list_item.dart
+++ b/lib/widgets/pages/ride_attendee_scanning_page/selectable_owner_list_item.dart
@@ -34,13 +34,13 @@ class SelectableOwnerListItem extends StatelessWidget {
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        final ThemeData theme = Theme.of(context);
+        final ColorScheme colorScheme = ColorScheme.of(context);
 
-        switch (theme.brightness) {
+        switch (Theme.of(context).brightness) {
           case Brightness.dark:
-            return theme.colorScheme.onPrimary;
+            return colorScheme.onPrimary;
           case Brightness.light:
-            return theme.colorScheme.primary;
+            return colorScheme.primary;
         }
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:

--- a/lib/widgets/pages/ride_details/ride_details_attendees/ride_details_attendees_list.dart
+++ b/lib/widgets/pages/ride_details/ride_details_attendees/ride_details_attendees_list.dart
@@ -59,7 +59,7 @@ class _ScannedAttendeesBottomBar extends ConsumerWidget {
 
   Widget _buildAndroidLayout(BuildContext context, {required int total, int? scannedAttendees}) {
     final translator = S.of(context);
-    final colorScheme = Theme.of(context).colorScheme;
+    final colorScheme = ColorScheme.of(context);
 
     return BottomAppBar(
       height: 56,

--- a/lib/widgets/pages/ride_details/ride_details_page.dart
+++ b/lib/widgets/pages/ride_details/ride_details_page.dart
@@ -60,7 +60,7 @@ class RideDetailsPageState extends ConsumerState<RideDetailsPage> {
   Widget _buildAndroidLayout(BuildContext context) {
     final translator = S.of(context);
 
-    final errorColor = Theme.of(context).colorScheme.error;
+    final errorColor = ColorScheme.of(context).error;
 
     return Scaffold(
       appBar: AppBar(

--- a/lib/widgets/pages/ride_list/ride_list_item.dart
+++ b/lib/widgets/pages/ride_list/ride_list_item.dart
@@ -21,7 +21,7 @@ class RideListItem extends ConsumerWidget {
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
-          return Theme.of(context).colorScheme.primary;
+          return ColorScheme.of(context).primary;
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
           return CupertinoTheme.of(context).primaryColor;

--- a/lib/widgets/pages/rider_details/rider_devices_list/delete_device_button.dart
+++ b/lib/widgets/pages/rider_details/rider_devices_list/delete_device_button.dart
@@ -19,7 +19,7 @@ class DeleteDeviceButton extends StatelessWidget {
     return PlatformAwareWidget(
       android: (context) {
         return IconButton(
-          icon: Icon(Icons.delete, color: Theme.of(context).colorScheme.error),
+          icon: Icon(Icons.delete, color: ColorScheme.of(context).error),
           onPressed: () => _onDeletePressed(context),
         );
       },

--- a/lib/widgets/pages/rider_details/rider_devices_list/rider_devices_list_header.dart
+++ b/lib/widgets/pages/rider_details/rider_devices_list/rider_devices_list_header.dart
@@ -12,11 +12,9 @@ class RiderDevicesListHeader extends StatelessWidget {
 
     return PlatformAwareWidget(
       android: (context) {
-        final textTheme = Theme.of(context).textTheme;
-
         return Padding(
           padding: const EdgeInsets.only(top: 4),
-          child: Text(title, style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold)),
+          child: Text(title, style: TextTheme.of(context).titleMedium?.copyWith(fontWeight: FontWeight.bold)),
         );
       },
       ios: (context) {

--- a/lib/widgets/pages/rider_details/rider_devices_list/rider_devices_list_item.dart
+++ b/lib/widgets/pages/rider_details/rider_devices_list/rider_devices_list_item.dart
@@ -74,7 +74,7 @@ class _EditDeviceButton extends ConsumerWidget {
     return PlatformAwareWidget(
       android: (context) {
         return IconButton(
-          icon: Icon(Icons.edit, color: Theme.of(context).colorScheme.primary),
+          icon: Icon(Icons.edit, color: ColorScheme.of(context).primary),
           onPressed: () => _onEditDevicePressed(context, ref),
         );
       },

--- a/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/add_excluded_term_input_field.dart
@@ -105,11 +105,7 @@ class _AddExcludedTermSuffixIcon extends StatelessWidget {
 
         return PlatformAwareWidget(
           android: (context) {
-            return IconButton(
-              color: Theme.of(context).colorScheme.primary,
-              icon: const Icon(Icons.check),
-              onPressed: onTap,
-            );
+            return IconButton(color: ColorScheme.of(context).primary, icon: const Icon(Icons.check), onPressed: onTap);
           },
           ios: (context) => CupertinoIconButton(icon: CupertinoIcons.checkmark_alt, onPressed: onTap),
         );

--- a/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field_button_bar.dart
+++ b/lib/widgets/pages/settings/excluded_terms/edit_excluded_term_input_field_button_bar.dart
@@ -48,7 +48,7 @@ class EditExcludedTermInputFieldButtonBar extends StatelessWidget {
       child: PlatformAwareWidget(
         android: (context) {
           return IconButton(
-            icon: Icon(Icons.delete, color: Theme.of(context).colorScheme.error),
+            icon: Icon(Icons.delete, color: ColorScheme.of(context).error),
             onPressed: () => onDeletePressed(context),
             padding: EdgeInsets.zero,
           );
@@ -69,7 +69,7 @@ class EditExcludedTermInputFieldButtonBar extends StatelessWidget {
         final confirmButton = PlatformAwareWidget(
           android: (context) {
             return IconButton(
-              color: Theme.of(context).colorScheme.primary,
+              color: ColorScheme.of(context).primary,
               icon: const Icon(Icons.check),
               onPressed: isValid ? () => onCommitValidTerm(currentValue) : null,
             );

--- a/lib/widgets/pages/settings/excluded_terms/excluded_term_input_field.dart
+++ b/lib/widgets/pages/settings/excluded_terms/excluded_term_input_field.dart
@@ -82,7 +82,7 @@ class ExcludedTermInputField extends StatelessWidget {
           controller: controller,
           decoration: InputDecoration(
             border: MaterialStateUnderlineInputBorder.resolveWith((states) {
-              final ColorScheme colorScheme = Theme.of(context).colorScheme;
+              final ColorScheme colorScheme = ColorScheme.of(context);
               Color color = const Color(0xFFD5D5D5);
 
               if (states.contains(WidgetState.error)) {

--- a/lib/widgets/pages/settings/excluded_terms/excluded_terms_list_empty.dart
+++ b/lib/widgets/pages/settings/excluded_terms/excluded_terms_list_empty.dart
@@ -15,7 +15,7 @@ class ExcludedTermsListEmpty extends StatelessWidget {
       android: (context) {
         return Padding(
           padding: const EdgeInsets.all(4),
-          child: Text(text, style: Theme.of(context).textTheme.bodySmall, textAlign: TextAlign.center),
+          child: Text(text, style: TextTheme.of(context).bodySmall, textAlign: TextAlign.center),
         );
       },
       ios: (context) {

--- a/lib/widgets/pages/settings/excluded_terms/excluded_terms_list_footer.dart
+++ b/lib/widgets/pages/settings/excluded_terms/excluded_terms_list_footer.dart
@@ -16,7 +16,7 @@ class ExcludedTermsListFooter extends StatelessWidget {
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        return Text(description, style: Theme.of(context).textTheme.bodySmall?.copyWith(fontStyle: FontStyle.italic));
+        return Text(description, style: TextTheme.of(context).bodySmall?.copyWith(fontStyle: FontStyle.italic));
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         return Text(

--- a/lib/widgets/pages/settings/excluded_terms/excluded_terms_list_header.dart
+++ b/lib/widgets/pages/settings/excluded_terms/excluded_terms_list_header.dart
@@ -16,7 +16,7 @@ class ExcludedTermsListHeader extends StatelessWidget {
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        return Text(title, style: Theme.of(context).textTheme.titleMedium);
+        return Text(title, style: TextTheme.of(context).titleMedium);
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         return Text(

--- a/lib/widgets/pages/settings/scan_duration_option.dart
+++ b/lib/widgets/pages/settings/scan_duration_option.dart
@@ -41,7 +41,7 @@ class ScanDurationOption extends StatelessWidget {
           children: [
             Padding(
               padding: const EdgeInsets.only(bottom: 4),
-              child: Text(translator.scanDuration, style: Theme.of(context).textTheme.titleMedium),
+              child: Text(translator.scanDuration, style: TextTheme.of(context).titleMedium),
             ),
             StreamBuilder<double>(
               initialData: delegate.currentValue,

--- a/lib/widgets/pages/settings/settings_page.dart
+++ b/lib/widgets/pages/settings/settings_page.dart
@@ -77,7 +77,7 @@ class SettingsPageState extends ConsumerState<SettingsPage> {
 
   Widget _buildAndroidWidget(BuildContext context) {
     final translator = S.of(context);
-    final textTheme = Theme.of(context).textTheme;
+    final textTheme = TextTheme.of(context);
 
     return SettingsPageScrollView(
       scrollController: scrollController,

--- a/lib/widgets/platform/platform_aware_icon.dart
+++ b/lib/widgets/platform/platform_aware_icon.dart
@@ -35,7 +35,7 @@ class PlatformAwareIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PlatformAwareWidget(
-      android: (context) => Icon(androidIcon, color: androidColor ?? Theme.of(context).colorScheme.primary, size: size),
+      android: (context) => Icon(androidIcon, color: androidColor ?? ColorScheme.of(context).primary, size: size),
       ios: (context) => Icon(iosIcon, color: iosColor ?? CupertinoTheme.of(context).primaryColor, size: size),
     );
   }

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -145,7 +145,7 @@ class RideCalendarTheme {
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         final ThemeData theme = Theme.of(context);
-        final ColorScheme colorScheme = theme.colorScheme;
+        final ColorScheme colorScheme = ColorScheme.of(context);
 
         switch (state) {
           case RideCalendarItemState.currentSelection:


### PR DESCRIPTION
This PR adjusts the raw lookups from the ambient Material Theme to use the static methods for `ColorScheme` & `TextTheme`